### PR TITLE
Fix FormData handling for activity creation

### DIFF
--- a/src/components/familjeschema/FamilySchedule.tsx
+++ b/src/components/familjeschema/FamilySchedule.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { AlertCircle } from 'lucide-react';
 import { scheduleService } from '@/services/scheduleService';
-import type { Activity, FamilyMember, FormData, Settings } from './types';
+import type { Activity, FamilyMember, ActivityFormData, Settings } from './types';
 import { WEEKDAYS_FULL, WEEKEND_DAYS, ALL_DAYS } from './constants';
 import { getWeekNumber, getWeekDateRange, isWeekInPast, isWeekInFuture } from './utils/dateUtils';
 import { generateTimeSlots } from './utils/scheduleUtils';
@@ -20,7 +20,7 @@ import { ActivityModal } from './components/ActivityModal';
 import { SettingsModal } from './components/SettingsModal';
 import { DataModal } from './components/DataModal';
 
-const BLANK_FORM: FormData = {
+const BLANK_FORM: ActivityFormData = {
   name: '', icon: '🎯', days: [], participants: [], startTime: '09:00',
   endTime: '10:00', location: '', notes: '', recurring: false,
   recurringEndDate: '', color: undefined
@@ -47,7 +47,7 @@ export function FamilySchedule() {
   const [showWeekPicker, setShowWeekPicker] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [dataModalOpen, setDataModalOpen] = useState(false);
-  const [formData, setFormData] = useState<FormData>(BLANK_FORM);
+  const [formData, setFormData] = useState<ActivityFormData>(BLANK_FORM);
   const [highlightedMemberId, setHighlightedMemberId] = useState<string | null>(null);
   const [showConflict, setShowConflict] = useState(false);
 
@@ -114,7 +114,12 @@ export function FamilySchedule() {
         const updates: Partial<Activity> = { ...formData, day: formData.days[0] };
         await scheduleService.updateActivity(editingActivity.id, updates);
       } else {
-        await scheduleService.createActivity(formData);
+        const dataToSend = new FormData();
+        Object.keys(formData).forEach((key) => {
+          const value = formData[key as keyof ActivityFormData];
+          dataToSend.append(key, String(value));
+        });
+        await scheduleService.createActivity(dataToSend);
       }
       await fetchData();
       setModalOpen(false);

--- a/src/components/familjeschema/components/ActivityModal.tsx
+++ b/src/components/familjeschema/components/ActivityModal.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, useState } from 'react';
 import { X, Save, Trash2, Repeat } from 'lucide-react';
-import type { FormData, FamilyMember } from '../types';
+import type { ActivityFormData, FamilyMember } from '../types';
 import { SizableModal } from './SizableModal';
 import { ACTIVITY_COLORS } from '../constants';
 import { IconPicker } from './IconPicker';
@@ -8,13 +8,13 @@ import { IconPicker } from './IconPicker';
 interface ActivityModalProps {
   isOpen: boolean;
   isEditing: boolean;
-  formData: FormData;
+  formData: ActivityFormData;
   familyMembers: FamilyMember[];
   days: string[];
   onClose: () => void;
   onSave: () => void;
   onDelete: () => void;
-  onFormChange: (data: FormData) => void;
+  onFormChange: (data: ActivityFormData) => void;
 }
 
 export const ActivityModal = forwardRef<HTMLDivElement, ActivityModalProps>(

--- a/src/components/familjeschema/types/index.ts
+++ b/src/components/familjeschema/types/index.ts
@@ -21,7 +21,7 @@ export interface Activity {
   color?: string;
 }
 
-export interface FormData {
+export interface ActivityFormData {
   name: string;
   icon: string;
   days: string[];

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -19,23 +19,23 @@ export const authHeader = (): HeadersInit => {
 
 // Enhanced fetch with authentication
 export const fetchWithAuth = async (
-  url: string, 
+  url: string,
   options: RequestInit = {}
 ): Promise<Response> => {
-  // Get auth headers
-  const headers = authHeader();
-  
-  // Merge with existing headers
-  const mergedHeaders = {
-    ...headers,
-    'Content-Type': 'application/json',
-    ...options.headers
-  };
-  
-  // Create the fetch request with merged headers
+  const headers = new Headers(options.headers || {});
+  const token = getToken();
+
+  if (token) {
+    headers.set('Authorization', `Bearer ${token}`);
+  }
+
+  if (!(options.body instanceof FormData)) {
+    headers.set('Content-Type', 'application/json');
+  }
+
   const response = await fetch(url, {
     ...options,
-    headers: mergedHeaders
+    headers
   });
   
   // Handle 401 Unauthorized responses (token expired or invalid)

--- a/src/services/scheduleService.ts
+++ b/src/services/scheduleService.ts
@@ -2,7 +2,7 @@
 import { fetchWithAuth } from './authService';
 
 // Vi importerar typerna från den plats de kommer att ha efter migreringen
-import type { Activity, FamilyMember, Settings, FormData } from '@/components/familjeschema/types';
+import type { Activity, FamilyMember, Settings } from '@/components/familjeschema/types';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://tobiaslundh1.pythonanywhere.com/api';
 const SCHEDULE_API_URL = `${API_URL}/schedule`;
@@ -23,9 +23,13 @@ export const scheduleService = {
   async createActivity(activityData: FormData): Promise<Activity> {
     const response = await fetchWithAuth(`${SCHEDULE_API_URL}/activities`, {
       method: 'POST',
-      body: JSON.stringify(activityData),
+      body: activityData,
     });
-    if (!response.ok) throw new Error('Failed to create activity');
+    if (!response.ok) {
+      const errorData = await response.json();
+      console.error('Failed to create activity:', errorData);
+      throw new Error(errorData.message || 'Failed to create activity');
+    }
     const data = await response.json();
     return data.data;
   },


### PR DESCRIPTION
## Summary
- send FormData directly when creating schedule activities
- skip JSON content-type for FormData requests in fetchWithAuth
- improve error reporting on activity creation failures

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Can't resolve dependencies such as `emoji-picker-react`)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc09243548323a83719ed875458e9