### PR TITLE
Refactor services for new API response format

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -54,11 +54,10 @@ export default function Home() {
     setError(null);
     try {
       const response = await fetchWithAuth(`${API_URL}/files`);
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
+      if (!response.success) {
+        throw new Error(response.error || 'Failed to load data');
       }
-      const json = await response.json();
-      setData(json);
+      setData(response);
     } catch (e: any) {
       console.error("Fetch error:", e);
       setError('Failed to load data.');
@@ -80,10 +79,8 @@ export default function Home() {
         },
       });
 
-      const updateData = await updateResponse.json();
-
-      if (!updateResponse.ok) {
-        throw new Error(updateData.message || 'Failed to update data');
+      if (!updateResponse.success) {
+        throw new Error(updateResponse.error || 'Failed to update data');
       }
 
       // Add a small delay to ensure the database has completed its update

--- a/src/components/FileList/FileListWindowWrapper.tsx
+++ b/src/components/FileList/FileListWindowWrapper.tsx
@@ -48,11 +48,10 @@ const FileListWindowWrapper: React.FC<FileListWindowWrapperProps> = ({
       try {
         // Fetch the specific section
         const response = await fetchWithAuth(`${API_URL}/files/section/${sectionId}`);
-        if (!response.ok) {
-          throw new Error(`HTTP error! status: ${response.status}`);
+        if (!response.success) {
+          throw new Error(response.error || 'Failed to load section data');
         }
-        const json = await response.json();
-        setData(json.data);
+        setData(response.data.data);
       } catch (e: any) {
         console.error("Fetch error:", e);
         setError('Failed to load section data.');

--- a/src/components/FileList/FileSectionsDropdown.tsx
+++ b/src/components/FileList/FileSectionsDropdown.tsx
@@ -32,13 +32,12 @@ const FileSectionsDropdown: React.FC<FileSectionsDropdownProps> = ({ onSectionSe
       setError(null);
       try {
         const response = await fetchWithAuth(`${API_URL}/files`);
-        if (!response.ok) {
-          throw new Error(`HTTP error! status: ${response.status}`);
+        if (!response.success) {
+          throw new Error(response.error || 'Failed to load sections');
         }
-        const json = await response.json();
-        
+
         // Transform the data for dropdown use
-        const sectionsData = json.data.map((section: any) => ({
+        const sectionsData = response.data.data.map((section: any) => ({
           name: section.name,
           id: section.name.toLowerCase().replace(/\s+/g, '-'),
           data: section

--- a/src/components/familjeschema/FamilySchedule.tsx
+++ b/src/components/familjeschema/FamilySchedule.tsx
@@ -104,22 +104,17 @@ export function FamilySchedule() {
   useFocusTrap(modalRef, modalOpen);
   useFocusTrap(settingsModalRef, settingsOpen);
 
-  const handleSaveActivity = async () => {
-    if (!formData.name || formData.days.length === 0 || formData.participants.length === 0) {
+  const handleSaveActivity = async (data: ActivityFormData) => {
+    if (!data.name || data.days.length === 0 || data.participants.length === 0) {
       alert('Fyll i alla obligatoriska fält!');
       return;
     }
     try {
       if (editingActivity) {
-        const updates: Partial<Activity> = { ...formData, day: formData.days[0] };
+        const updates: Partial<Activity> = { ...data, day: data.days[0] };
         await scheduleService.updateActivity(editingActivity.id, updates);
       } else {
-        const dataToSend = new FormData();
-        Object.keys(formData).forEach((key) => {
-          const value = formData[key as keyof ActivityFormData];
-          dataToSend.append(key, String(value));
-        });
-        await scheduleService.createActivity(dataToSend);
+        await scheduleService.createActivity({ ...data, day: data.days[0] });
       }
       await fetchData();
       setModalOpen(false);

--- a/src/components/familjeschema/components/ActivityModal.tsx
+++ b/src/components/familjeschema/components/ActivityModal.tsx
@@ -12,7 +12,7 @@ interface ActivityModalProps {
   familyMembers: FamilyMember[];
   days: string[];
   onClose: () => void;
-  onSave: () => void;
+  onSave: (data: ActivityFormData) => void;
   onDelete: () => void;
   onFormChange: (data: ActivityFormData) => void;
 }
@@ -288,7 +288,7 @@ export const ActivityModal = forwardRef<HTMLDivElement, ActivityModalProps>(
             <button className="btn" onClick={onClose}>Avbryt</button>
             <button
               className="btn btn-success"
-              onClick={onSave}
+              onClick={() => onSave(formData)}
               aria-label="Spara aktivitet"
             >
               <Save size={20}/> Spara

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -65,13 +65,14 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         headers: {
           'Content-Type': 'application/json',
         },
+        credentials: 'include',
         body: JSON.stringify({ username, password }),
       });
 
       const data = await response.json();
 
-      if (!response.ok) {
-        throw new Error(data.message || 'Login failed');
+      if (!data.success) {
+        throw new Error(data.error || 'Login failed');
       }
 
       // Save token and user in state and localStorage
@@ -99,13 +100,14 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         headers: {
           'Content-Type': 'application/json',
         },
+        credentials: 'include',
         body: JSON.stringify({ username, password, email }),
       });
 
       const data = await response.json();
 
-      if (!response.ok) {
-        throw new Error(data.message || 'Registration failed');
+      if (!data.success) {
+        throw new Error(data.error || 'Registration failed');
       }
 
       // Save token and user in state and localStorage

--- a/src/services/calendarService.ts
+++ b/src/services/calendarService.ts
@@ -53,16 +53,19 @@ export const calendarService = {
             
             console.log(`Fetching events from: ${url}`);
             const response = await fetchWithAuth(url);
-            
-            if (!response.ok) {
-                const errorText = await response.text();
-                console.error(`Event fetch error (${response.status}): ${errorText}`);
-                throw new Error(`Error fetching events: ${response.statusText}`);
+
+            if (!response.success) {
+                console.error('Event fetch error:', response.error);
+                throw new Error(response.error || 'Error fetching events');
             }
-            
-            const data = await response.json();
-            console.log(`Retrieved ${data.data?.length || 0} events:`, data.data);
-            return data.data || [];
+
+            const events = response.data?.data || [];
+            console.log(`Retrieved ${events.length} events:`, events);
+            return events.map((e: any) => ({
+                ...e,
+                start: Number(e.start),
+                end: Number(e.end)
+            }));
         } catch (error) {
             console.error('Error fetching events:', error);
             throw error;
@@ -85,16 +88,14 @@ export const calendarService = {
                 method: 'POST',
                 body: JSON.stringify(eventData),
             });
-            
-            if (!response.ok) {
-                const errorText = await response.text();
-                console.error(`Event creation error (${response.status}): ${errorText}`);
-                throw new Error(`Error creating event: ${response.statusText}`);
+
+            if (!response.success) {
+                console.error('Event creation error:', response.error);
+                throw new Error(response.error || 'Error creating event');
             }
-            
-            const data = await response.json();
-            console.log(`Event created with ID: ${data.data?.id}`, data.data);
-            return data.data;
+
+            console.log(`Event created with ID: ${response.data?.data?.id}`, response.data?.data);
+            return response.data.data;
         } catch (error) {
             console.error('Error creating event:', error);
             throw error;
@@ -125,16 +126,14 @@ export const calendarService = {
                 method: 'PUT',
                 body: JSON.stringify(eventUpdates),
             });
-            
-            if (!response.ok) {
-                const errorText = await response.text();
-                console.error(`Event update error (${response.status}): ${errorText}`);
-                throw new Error(`Error updating event: ${response.statusText}`);
+
+            if (!response.success) {
+                console.error('Event update error:', response.error);
+                throw new Error(response.error || 'Error updating event');
             }
-            
-            const data = await response.json();
-            console.log(`Event updated successfully:`, data.data);
-            return data.data;
+
+            console.log(`Event updated successfully:`, response.data.data);
+            return response.data.data;
         } catch (error) {
             console.error('Error updating event:', error);
             throw error;
@@ -147,13 +146,12 @@ export const calendarService = {
             const response = await fetchWithAuth(`${API_URL}/events/${id}`, {
                 method: 'DELETE',
             });
-            
-            if (!response.ok) {
-                const errorText = await response.text();
-                console.error(`Event deletion error (${response.status}): ${errorText}`);
-                throw new Error(`Error deleting event: ${response.statusText}`);
+
+            if (!response.success) {
+                console.error('Event deletion error:', response.error);
+                throw new Error(response.error || 'Error deleting event');
             }
-            
+
             console.log(`Event deleted successfully`);
         } catch (error) {
             console.error('Error deleting event:', error);
@@ -166,22 +164,18 @@ export const calendarService = {
             const dateStr = date.toISOString().split('T')[0]; // YYYY-MM-DD
             console.log(`Getting note for date: ${dateStr}`);
             const response = await fetchWithAuth(`${API_URL}/notes/${dateStr}`);
-            
-            if (!response.ok) {
-                // A 404 is expected if no note exists yet
-                if (response.status === 404) {
+
+            if (!response.success) {
+                if (response.error?.includes('Not Found')) {
                     console.log(`No note found for ${dateStr}`);
                     return { date: dateStr, notes: '' };
                 }
-                
-                const errorText = await response.text();
-                console.error(`Note fetch error (${response.status}): ${errorText}`);
-                throw new Error(`Error fetching day note: ${response.statusText}`);
+                console.error('Note fetch error:', response.error);
+                throw new Error(response.error || 'Error fetching day note');
             }
-            
-            const data = await response.json();
-            console.log(`Retrieved note for ${dateStr}:`, data.data);
-            return data.data;
+
+            console.log(`Retrieved note for ${dateStr}:`, response.data.data);
+            return response.data.data;
         } catch (error) {
             console.error('Error fetching day note:', error);
             throw error;
@@ -196,16 +190,14 @@ export const calendarService = {
                 method: 'POST',
                 body: JSON.stringify({ notes }),
             });
-            
-            if (!response.ok) {
-                const errorText = await response.text();
-                console.error(`Note save error (${response.status}): ${errorText}`);
-                throw new Error(`Error saving day note: ${response.statusText}`);
+
+            if (!response.success) {
+                console.error('Note save error:', response.error);
+                throw new Error(response.error || 'Error saving day note');
             }
-            
-            const data = await response.json();
-            console.log(`Note saved successfully for ${dateStr}:`, data.data);
-            return data.data;
+
+            console.log(`Note saved successfully for ${dateStr}:`, response.data.data);
+            return response.data.data;
         } catch (error) {
             console.error('Error saving day note:', error);
             throw error;

--- a/src/services/notesService.ts
+++ b/src/services/notesService.ts
@@ -10,242 +10,80 @@ export interface NoteFile {
     url?: string;
     created_time?: string;
 }
-  
+
 export interface NoteContent {
     id?: string;
     content: string;
     tags: string[];
     description: string;
 }
-  
+
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://tobiaslundh1.pythonanywhere.com/api';
-  
+
 export const notesService = {
     async listFiles(path: string): Promise<NoteFile[]> {
-        try {
-            console.log(`Fetching files from path: ${path}`);
-            const encodedPath = encodeURIComponent(path);
-            const url = `${API_URL}/notes/files?path=${encodedPath}`;
-            
-            console.log("API call URL:", url);
-            const response = await fetchWithAuth(url);
-            
-            const responseText = await response.text();
-            console.log("API response:", responseText);
-            
-            // Parse the response text
-            let data;
-            try {
-                data = JSON.parse(responseText);
-            } catch (e) {
-                console.error("Error parsing JSON response:", e);
-                throw new Error(`Invalid response format: ${responseText}`);
-            }
-            
-            if (!response.ok) {
-                console.error(`Error listing files (${response.status}):`, data);
-                throw new Error(`Error listing files: ${data.message || response.statusText}`);
-            }
-            
-            console.log(`Retrieved ${data.data?.length || 0} files:`, data.data);
-            return data.data || [];
-        } catch (error) {
-            console.error('Error listing files:', error);
-            throw error;
-        }
+        const encodedPath = encodeURIComponent(path);
+        const response = await fetchWithAuth(`${API_URL}/notes/files?path=${encodedPath}`);
+        if (!response.success) throw new Error(response.error || 'Error listing files');
+        return response.data.data || [];
     },
-    
+
     async createDirectory(path: string): Promise<void> {
-        try {
-            console.log(`Creating directory at path: ${path}`);
-            const response = await fetchWithAuth(`${API_URL}/notes/directory`, {
-                method: 'POST',
-                body: JSON.stringify({ path }),
-            });
-            
-            const responseText = await response.text();
-            console.log("API response:", responseText);
-            
-            let data;
-            try {
-                data = JSON.parse(responseText);
-            } catch (e) {
-                console.error("Error parsing JSON response:", e);
-                throw new Error(`Invalid response format: ${responseText}`);
-            }
-            
-            if (!response.ok) {
-                console.error(`Error creating directory (${response.status}):`, data);
-                throw new Error(`Error creating directory: ${data.message || response.statusText}`);
-            }
-            
-            console.log(`Directory created at ${path}`);
-        } catch (error) {
-            console.error('Error creating directory:', error);
-            throw error;
-        }
+        const response = await fetchWithAuth(`${API_URL}/notes/directory`, {
+            method: 'POST',
+            body: JSON.stringify({ path }),
+        });
+        if (!response.success) throw new Error(response.error || 'Error creating directory');
     },
-    
+
     async saveNote(path: string, content: string, metadata: { tags: string[], description: string }): Promise<void> {
-        try {
-            console.log(`Saving note at path: ${path}`);
-            console.log("Content length:", content.length);
-            console.log("Metadata:", metadata);
-            
-            const requestBody = {
-                path,
-                content,
-                tags: metadata.tags.join(','),
-                description: metadata.description,
-            };
-            
-            console.log("Request body:", JSON.stringify(requestBody));
-            
-            const response = await fetchWithAuth(`${API_URL}/notes/file`, {
-                method: 'POST',
-                body: JSON.stringify(requestBody),
-            });
-            
-            const responseText = await response.text();
-            console.log("API response:", responseText);
-            
-            let data;
-            try {
-                data = JSON.parse(responseText);
-            } catch (e) {
-                console.error("Error parsing JSON response:", e);
-                throw new Error(`Invalid response format: ${responseText}`);
-            }
-            
-            if (!response.ok) {
-                console.error(`Error saving note (${response.status}):`, data);
-                throw new Error(`Error saving note: ${data.message || response.statusText}`);
-            }
-            
-            console.log(`Note saved at ${path}`);
-        } catch (error) {
-            console.error('Error saving note:', error);
-            throw error;
-        }
+        const requestBody = {
+            path,
+            content,
+            tags: metadata.tags.join(','),
+            description: metadata.description,
+        };
+
+        const response = await fetchWithAuth(`${API_URL}/notes/file`, {
+            method: 'POST',
+            body: JSON.stringify(requestBody),
+        });
+        if (!response.success) throw new Error(response.error || 'Error saving note');
     },
-    
+
     async getNoteContent(path: string): Promise<NoteContent> {
-        try {
-            console.log(`Fetching note content from: ${path}`);
-            const encodedPath = encodeURIComponent(path);
-            const url = `${API_URL}/notes/file?path=${encodedPath}`;
-            
-            console.log("API call URL:", url);
-            const response = await fetchWithAuth(url);
-            
-            const responseText = await response.text();
-            console.log("API response:", responseText);
-            
-            // Parse the response text
-            let data;
-            try {
-                data = JSON.parse(responseText);
-            } catch (e) {
-                console.error("Error parsing JSON response:", e);
-                throw new Error(`Invalid response format: ${responseText}`);
+        const encodedPath = encodeURIComponent(path);
+        const response = await fetchWithAuth(`${API_URL}/notes/file?path=${encodedPath}`);
+        if (!response.success) {
+            if (response.error?.includes('not found')) {
+                throw new Error(`Note not found at ${path}`);
             }
-            
-            if (!response.ok) {
-                console.error(`Error fetching note (${response.status}):`, data);
-                
-                // If the note doesn't exist (404), throw a specific error
-                if (response.status === 404) {
-                    throw new Error(`Note not found at ${path}`);
-                }
-                
-                throw new Error(`Error fetching note: ${data.message || response.statusText}`);
-            }
-            
-            if (!data.data || typeof data.data.content !== 'string') {
-                console.error('Invalid response format:', data);
-                throw new Error('Invalid response format from server');
-            }
-            
-            console.log(`Retrieved note content:`, data.data);
-            
-            // Make sure we always return a properly formatted NoteContent
-            return {
-                content: data.data.content || '',
-                tags: Array.isArray(data.data.tags) ? data.data.tags : [],
-                description: data.data.description || '',
-                ...(data.data.id ? { id: data.data.id } : {})
-            };
-        } catch (error) {
-            console.error('Error fetching note content:', error);
-            throw error;
+            throw new Error(response.error || 'Error fetching note');
         }
+
+        const data = response.data.data || {};
+        return {
+            content: data.content || '',
+            tags: Array.isArray(data.tags) ? data.tags : [],
+            description: data.description || '',
+            ...(data.id ? { id: data.id } : {})
+        };
     },
-    
+
     async moveFile(sourcePath: string, destinationPath: string): Promise<void> {
-        try {
-            console.log(`Moving file from ${sourcePath} to ${destinationPath}`);
-            const response = await fetchWithAuth(`${API_URL}/notes/move`, {
-                method: 'POST',
-                body: JSON.stringify({
-                    source: sourcePath,
-                    destination: destinationPath,
-                }),
-            });
-            
-            const responseText = await response.text();
-            console.log("Move API response:", responseText);
-            
-            let data;
-            try {
-                data = JSON.parse(responseText);
-            } catch (e) {
-                console.error("Error parsing JSON response:", e);
-                throw new Error(`Invalid response format: ${responseText}`);
-            }
-            
-            if (!response.ok) {
-                console.error(`Error moving file (${response.status}):`, data);
-                throw new Error(`Error moving file: ${data.message || response.statusText}`);
-            }
-            
-            console.log(`File moved successfully from ${sourcePath} to ${destinationPath}`);
-        } catch (error) {
-            console.error('Error moving file:', error);
-            throw error;
-        }
+        const response = await fetchWithAuth(`${API_URL}/notes/move`, {
+            method: 'POST',
+            body: JSON.stringify({ source: sourcePath, destination: destinationPath }),
+        });
+        if (!response.success) throw new Error(response.error || 'Error moving file');
     },
-    
+
     async deleteFile(path: string): Promise<void> {
-        try {
-            console.log(`Deleting file at path: ${path}`);
-            const encodedPath = encodeURIComponent(path);
-            const url = `${API_URL}/notes/file?path=${encodedPath}`;
-            
-            console.log("Delete API call URL:", url);
-            const response = await fetchWithAuth(url, {
-                method: 'DELETE',
-            });
-            
-            const responseText = await response.text();
-            console.log("Delete API response:", responseText);
-            
-            let data;
-            try {
-                data = JSON.parse(responseText);
-            } catch (e) {
-                console.error("Error parsing JSON response:", e);
-                throw new Error(`Invalid response format: ${responseText}`);
-            }
-            
-            if (!response.ok) {
-                console.error(`Error deleting file (${response.status}):`, data);
-                throw new Error(`Error deleting file: ${data.message || response.statusText}`);
-            }
-            
-            console.log(`File successfully deleted at ${path}`);
-        } catch (error) {
-            console.error('Error deleting file:', error);
-            throw error;
-        }
+        const encodedPath = encodeURIComponent(path);
+        const response = await fetchWithAuth(`${API_URL}/notes/file?path=${encodedPath}`, {
+            method: 'DELETE',
+        });
+        if (!response.success) throw new Error(response.error || 'Error deleting file');
     }
 };
+

--- a/src/services/scheduleService.ts
+++ b/src/services/scheduleService.ts
@@ -15,47 +15,43 @@ export const scheduleService = {
   // --- Aktiviteter ---
   async getActivities(): Promise<Activity[]> {
     const response = await fetchWithAuth(`${SCHEDULE_API_URL}/activities`);
-    if (!response.ok) throw new Error('Failed to fetch activities');
-    const data = await response.json();
-    return data.data || [];
+    if (!response.success) throw new Error(response.error || 'Failed to fetch activities');
+    return response.data?.data || [];
   },
 
-  async createActivity(activityData: FormData): Promise<Activity> {
+  async createActivity(activityData: Partial<Activity>): Promise<Activity> {
     const response = await fetchWithAuth(`${SCHEDULE_API_URL}/activities`, {
       method: 'POST',
-      body: activityData,
+      body: JSON.stringify(activityData),
     });
-    if (!response.ok) {
-      const errorData = await response.json();
-      console.error('Failed to create activity:', errorData);
-      throw new Error(errorData.message || 'Failed to create activity');
+    if (!response.success) {
+      console.error('Failed to create activity:', response);
+      throw new Error(response.error || 'Failed to create activity');
     }
-    const data = await response.json();
-    return data.data;
+    return response.data.data;
   },
-  
+
   async updateActivity(id: string, activityData: Partial<Activity>): Promise<Activity> {
     const response = await fetchWithAuth(`${SCHEDULE_API_URL}/activities/${id}`, {
       method: 'PUT',
       body: JSON.stringify(activityData),
     });
-    if (!response.ok) throw new Error('Failed to update activity');
-    const data = await response.json();
-    return data.data;
+    if (!response.success) throw new Error(response.error || 'Failed to update activity');
+    return response.data.data;
   },
 
   async deleteActivity(id: string): Promise<void> {
     const response = await fetchWithAuth(`${SCHEDULE_API_URL}/activities/${id}`, {
       method: 'DELETE',
     });
-    if (!response.ok) throw new Error('Failed to delete activity');
+    if (!response.success) throw new Error(response.error || 'Failed to delete activity');
   },
 
   async deleteActivitySeries(seriesId: string): Promise<void> {
     const response = await fetchWithAuth(`${SCHEDULE_API_URL}/activities/series/${seriesId}`, {
       method: 'DELETE',
     });
-    if (!response.ok) throw new Error('Failed to delete activity series');
+    if (!response.success) throw new Error(response.error || 'Failed to delete activity series');
   },
 
   // --- LLM/JSON Import ---
@@ -64,22 +60,19 @@ export const scheduleService = {
       method: 'POST',
       body: JSON.stringify({ activities }),
     });
-    const data = await response.json();
-    if (!response.ok) {
-        // Kasta ett fel med detaljerad information från backend
-        const error = new Error(data.message || 'Failed to import activities');
-        (error as any).details = data.conflicts; // Lägg till konfliktdetaljer i felet
+    if (!response.success) {
+        const error = new Error(response.error || 'Failed to import activities');
+        (error as any).details = response.data?.conflicts;
         throw error;
     }
-    return data;
+    return response.data;
   },
 
   // --- Familjemedlemmar ---
   async getFamilyMembers(): Promise<FamilyMember[]> {
     const response = await fetchWithAuth(`${SCHEDULE_API_URL}/family-members`);
-    if (!response.ok) throw new Error('Failed to fetch family members');
-    const data = await response.json();
-    return data.data || [];
+    if (!response.success) throw new Error(response.error || 'Failed to fetch family members');
+    return response.data?.data || [];
   },
 
   // ... (funktioner för att skapa/uppdatera/ta bort familjemedlemmar kan läggas till här)
@@ -87,9 +80,8 @@ export const scheduleService = {
   // --- Inställningar ---
   async getSettings(): Promise<Settings> {
     const response = await fetchWithAuth(`${SCHEDULE_API_URL}/settings`);
-    if (!response.ok) throw new Error('Failed to fetch settings');
-    const data = await response.json();
-    return data.data;
+    if (!response.success) throw new Error(response.error || 'Failed to fetch settings');
+    return response.data.data;
   },
 
   async updateSettings(settings: Settings): Promise<Settings> {
@@ -97,8 +89,7 @@ export const scheduleService = {
         method: 'PUT',
         body: JSON.stringify(settings)
     });
-    if (!response.ok) throw new Error('Failed to update settings');
-    const data = await response.json();
-    return data.data;
+    if (!response.success) throw new Error(response.error || 'Failed to update settings');
+    return response.data.data;
   }
 };


### PR DESCRIPTION
## Summary
- add token refresh and credential support to auth fetch helper
- send JSON bodies and handle nested `data` across schedule, calendar, and notes services
- update components and context to check `response.success`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd7818d8408323a93f9486e598a9ee