### PR TITLE
Send week and year when retrieving schedule activities

### DIFF
--- a/src/components/familjeschema/FamilySchedule.tsx
+++ b/src/components/familjeschema/FamilySchedule.tsx
@@ -77,7 +77,7 @@ export function FamilySchedule() {
       setLoading(true);
       setError(null);
       const [activitiesData, membersData, settingsData] = await Promise.all([
-        scheduleService.getActivities(),
+        scheduleService.getActivities(selectedYear, selectedWeek),
         scheduleService.getFamilyMembers(),
         scheduleService.getSettings()
       ]);
@@ -197,6 +197,18 @@ export function FamilySchedule() {
     setDataModalOpen(false);
   };
 
+  const fetchActivities = async (year: number, week: number) => {
+    try {
+      setLoading(true);
+      const fetchedActivities = await scheduleService.getActivities(year, week);
+      setActivities(fetchedActivities);
+    } catch (error) {
+      console.error("Failed to fetch activities for new week", error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
   const currentWeek = getWeekNumber(new Date());
   const currentYear = new Date().getFullYear();
   const isCurrentWeek = selectedWeek === currentWeek && selectedYear === currentYear;
@@ -207,13 +219,17 @@ export function FamilySchedule() {
   const navigateWeek = (direction: number) => {
     const monday = getWeekDateRange(selectedWeek, selectedYear, 1)[0];
     monday.setDate(monday.getDate() + direction * 7);
-    setSelectedWeek(getWeekNumber(monday));
-    setSelectedYear(monday.getFullYear());
+    const newWeek = getWeekNumber(monday);
+    const newYear = monday.getFullYear();
+    setSelectedWeek(newWeek);
+    setSelectedYear(newYear);
+    fetchActivities(newYear, newWeek);
   };
-  
+
   const goToCurrentWeek = () => {
     setSelectedWeek(currentWeek);
     setSelectedYear(currentYear);
+    fetchActivities(currentYear, currentWeek);
   };
 
   const handleActivityClick = (activity: Activity) => {

--- a/src/services/scheduleService.ts
+++ b/src/services/scheduleService.ts
@@ -13,8 +13,9 @@ type ActivityImportItem = Partial<Omit<Activity, 'id'>>;
 export const scheduleService = {
   
   // --- Aktiviteter ---
-  async getActivities(): Promise<Activity[]> {
-    const response = await fetchWithAuth(`${SCHEDULE_API_URL}/activities`);
+  async getActivities(year: number, week: number): Promise<Activity[]> {
+    const url = `${SCHEDULE_API_URL}/activities?year=${year}&week=${week}`;
+    const response = await fetchWithAuth(url);
     if (!response.ok) throw new Error('Failed to fetch activities');
     const data = await response.json();
     return data.data || [];


### PR DESCRIPTION
## Summary
- add year/week query parameters to getActivities service
- fetch activities for selected week in FamilySchedule and handle week navigation

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68be06953a8c83238e75110db576b734