### PR TITLE
Ensure auth token for activity creation and set UTF-8 charset

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -28,7 +28,7 @@ const monument = localFont({
 })
 
 export const metadata: Metadata = {
-  title: 'Bibliotek',
+  title: 'Drive C',
 }
 
 export default function RootLayout({
@@ -38,6 +38,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
+      <head>
+        <meta charSet="UTF-8" />
+        <title>Drive C</title>
+      </head>
       <body className={`${redHat.className} ${monument.variable} min-h-screen bg-[#fcd7d7]`}>
         <AuthProvider>
           {/* Top Navigation Bar */}

--- a/src/components/familjeschema/FamilySchedule.tsx
+++ b/src/components/familjeschema/FamilySchedule.tsx
@@ -2,7 +2,8 @@
 
 import { useState, useEffect, useRef } from 'react';
 import { AlertCircle } from 'lucide-react';
-import { scheduleService } from '@/services/scheduleService';
+import { scheduleService, createActivity } from '@/services/scheduleService';
+import { getToken } from '@/services/authService';
 import type { Activity, FamilyMember, FormData, Settings } from './types';
 import { WEEKDAYS_FULL, WEEKEND_DAYS, ALL_DAYS } from './constants';
 import { getWeekNumber, getWeekDateRange, isWeekInPast, isWeekInFuture } from './utils/dateUtils';
@@ -114,7 +115,9 @@ export function FamilySchedule() {
         const updates: Partial<Activity> = { ...formData, day: formData.days[0] };
         await scheduleService.updateActivity(editingActivity.id, updates);
       } else {
-        await scheduleService.createActivity(formData);
+        const token = getToken();
+        if (!token) throw new Error('Authentication token is missing');
+        await createActivity(formData as any, token);
       }
       await fetchData();
       setModalOpen(false);


### PR DESCRIPTION
## Summary
- add explicit createActivity helper that includes Authorization token
- pass auth token from FamilySchedule when creating new activities
- specify UTF-8 charset and title in root layout for proper emoji rendering

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68be08f21d048323919ef12263907b71