### PR TITLE
refactor: handle activity creation in schedule service

### DIFF
--- a/src/components/familjeschema/types/index.ts
+++ b/src/components/familjeschema/types/index.ts
@@ -21,6 +21,20 @@ export interface Activity {
   color?: string;
 }
 
+export interface CreateActivityPayload {
+  name: string;
+  icon: string;
+  days: string[];
+  participants: string[];
+  startTime: string;
+  endTime: string;
+  location?: string;
+  notes?: string;
+  color?: string;
+  week: number;
+  year: number;
+}
+
 export interface FormData {
   name: string;
   icon: string;

--- a/src/services/scheduleService.ts
+++ b/src/services/scheduleService.ts
@@ -2,39 +2,18 @@
 import { fetchWithAuth } from './authService';
 
 // Vi importerar typerna från den plats de kommer att ha efter migreringen
-import type { Activity, FamilyMember, Settings } from '@/components/familjeschema/types';
+import type {
+  Activity,
+  FamilyMember,
+  Settings,
+  CreateActivityPayload,
+} from '@/components/familjeschema/types';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://tobiaslundh1.pythonanywhere.com/api';
 const SCHEDULE_API_URL = `${API_URL}/schedule`;
 
 // Typ för JSON-import från LLM
 type ActivityImportItem = Partial<Omit<Activity, 'id'>>;
-
-export const createActivity = async (
-  activity: Omit<Activity, 'id' | 'seriesId'>,
-  token: string
-): Promise<any> => {
-  try {
-    const response = await fetch(`${API_URL}/schedule/activities`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
-      },
-      body: JSON.stringify(activity),
-    });
-
-    const data = await response.json();
-    if (!response.ok) {
-      // Använd felmeddelandet från servern om det finns, annars ett standardmeddelande
-      throw new Error(data.error || 'Failed to create activity');
-    }
-    return data;
-  } catch (error) {
-    console.error('Error creating activity:', error);
-    throw error;
-  }
-};
 
 export const scheduleService = {
 
@@ -46,8 +25,18 @@ export const scheduleService = {
     const data = await response.json();
     return data.data || [];
   },
-  
-  async updateActivity(id: string, activityData: Partial<Activity>): Promise<Activity> {
+
+  async createActivity(activityData: CreateActivityPayload): Promise<Activity> {
+    const response = await fetchWithAuth(`${SCHEDULE_API_URL}/activities`, {
+      method: 'POST',
+      body: JSON.stringify(activityData),
+    });
+    if (!response.ok) throw new Error('Failed to create activity');
+    const data = await response.json();
+    return data.data;
+  },
+
+  async updateActivity(id: string, activityData: CreateActivityPayload): Promise<Activity> {
     const response = await fetchWithAuth(`${SCHEDULE_API_URL}/activities/${id}`, {
       method: 'PUT',
       body: JSON.stringify(activityData),


### PR DESCRIPTION
## Summary
- remove unused selectedActivity state from family schedule
- add CreateActivityPayload type and use it in schedule handling
- move activity creation into scheduleService with authenticated fetch

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68bf603792b88323866a4906964d940c