### PR TITLE
feat: support series updates in schedule

### DIFF
--- a/src/services/scheduleService.ts
+++ b/src/services/scheduleService.ts
@@ -46,6 +46,16 @@ export const scheduleService = {
     return data.data;
   },
 
+  async updateActivitySeries(seriesId: string, activityData: Partial<Activity>): Promise<Activity[]> {
+    const response = await fetchWithAuth(`${SCHEDULE_API_URL}/activities/series/${seriesId}`, {
+      method: 'PUT',
+      body: JSON.stringify(activityData),
+    });
+    if (!response.ok) throw new Error('Failed to update activity series');
+    const data = await response.json();
+    return data.data || [];
+  },
+
   async deleteActivity(id: string): Promise<void> {
     const response = await fetchWithAuth(`${SCHEDULE_API_URL}/activities/${id}`, {
       method: 'DELETE',


### PR DESCRIPTION
## Summary
- add scheduleService.updateActivitySeries for updating all activities in a series
- prompt users in ActivityModal to choose between single or series-wide actions
- update FamilySchedule to handle series updates/deletions and sync local state without refetch

## Testing
- `pnpm lint`
- `pnpm tsc --noEmit` *(fails: Cannot find module '@radix-ui/react-dialog' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68c15e0c31748323977f071d8540a002