### PR TITLE
Handle recurring end date for schedule activities

### DIFF
--- a/src/components/familjeschema/FamilySchedule.tsx
+++ b/src/components/familjeschema/FamilySchedule.tsx
@@ -126,6 +126,10 @@ export function FamilySchedule() {
         year: selectedYear,
       };
 
+      if (activityFromForm.recurring) {
+        payload.recurringEndDate = activityFromForm.recurringEndDate;
+      }
+
       if (editingActivity) {
         if (applyToSeries && editingActivity.seriesId) {
           const updatedActivities = await scheduleService.updateActivitySeries(editingActivity.seriesId, payload);
@@ -137,8 +141,8 @@ export function FamilySchedule() {
           setActivities(prev => prev.map(a => (a.id === updatedActivity.id ? updatedActivity : a)));
         }
       } else {
-        const newActivity = await scheduleService.createActivity(payload);
-        setActivities(prev => [...prev, newActivity]);
+        const created = await scheduleService.createActivity(payload);
+        setActivities(prev => [...prev, ...created]);
       }
 
       setModalOpen(false);

--- a/src/components/familjeschema/types/index.ts
+++ b/src/components/familjeschema/types/index.ts
@@ -33,6 +33,7 @@ export interface CreateActivityPayload {
   color?: string;
   week: number;
   year: number;
+  recurringEndDate?: string;
 }
 
 export interface FormData {

--- a/src/services/scheduleService.ts
+++ b/src/services/scheduleService.ts
@@ -26,14 +26,14 @@ export const scheduleService = {
     return data.data || [];
   },
 
-  async createActivity(activityData: CreateActivityPayload): Promise<Activity> {
+  async createActivity(activityData: CreateActivityPayload): Promise<Activity[]> {
     const response = await fetchWithAuth(`${SCHEDULE_API_URL}/activities`, {
       method: 'POST',
       body: JSON.stringify(activityData),
     });
     if (!response.ok) throw new Error('Failed to create activity');
     const data = await response.json();
-    return data.data;
+    return data.data || [];
   },
 
   async updateActivity(id: string, activityData: CreateActivityPayload): Promise<Activity> {


### PR DESCRIPTION
## Summary
- Support recurring activity end dates and append created entries
- Allow schedule service to return multiple created activities

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1654be8c8832391863cf1233a9dd3