### PR TITLE
Handle recurring end date in activity creation

### DIFF
--- a/src/components/familjeschema/FamilySchedule.tsx
+++ b/src/components/familjeschema/FamilySchedule.tsx
@@ -126,6 +126,10 @@ export function FamilySchedule() {
         year: selectedYear,
       };
 
+      if (activityFromForm.recurring && activityFromForm.recurringEndDate) {
+        payload.recurringEndDate = activityFromForm.recurringEndDate;
+      }
+
       if (editingActivity) {
         if (applyToSeries && editingActivity.seriesId) {
           const updatedActivities = await scheduleService.updateActivitySeries(editingActivity.seriesId, payload);
@@ -137,8 +141,8 @@ export function FamilySchedule() {
           setActivities(prev => prev.map(a => (a.id === updatedActivity.id ? updatedActivity : a)));
         }
       } else {
-        const newActivity = await scheduleService.createActivity(payload);
-        setActivities(prev => [...prev, newActivity]);
+        const newActivities = await scheduleService.createActivity(payload);
+        setActivities(prev => [...prev, ...newActivities]);
       }
 
       setModalOpen(false);

--- a/src/components/familjeschema/types/index.ts
+++ b/src/components/familjeschema/types/index.ts
@@ -33,6 +33,7 @@ export interface CreateActivityPayload {
   color?: string;
   week: number;
   year: number;
+  recurringEndDate?: string;
 }
 
 export interface FormData {

--- a/src/services/scheduleService.ts
+++ b/src/services/scheduleService.ts
@@ -26,14 +26,18 @@ export const scheduleService = {
     return data.data || [];
   },
 
-  async createActivity(activityData: CreateActivityPayload): Promise<Activity> {
+  async createActivity(activityData: CreateActivityPayload): Promise<Activity[]> {
+    const body: Record<string, unknown> = { ...activityData };
+    if ('recurringEndDate' in activityData && activityData.recurringEndDate) {
+      body.recurringEndDate = activityData.recurringEndDate;
+    }
     const response = await fetchWithAuth(`${SCHEDULE_API_URL}/activities`, {
       method: 'POST',
-      body: JSON.stringify(activityData),
+      body: JSON.stringify(body),
     });
     if (!response.ok) throw new Error('Failed to create activity');
     const data = await response.json();
-    return data.data;
+    return data.data || [];
   },
 
   async updateActivity(id: string, activityData: CreateActivityPayload): Promise<Activity> {


### PR DESCRIPTION
## Summary
- include `recurringEndDate` when creating activities and return full list
- forward optional recurring end date from form handling
- allow payloads to include an optional `recurringEndDate`

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1654c5cc4832392fab398be06b3d1