### PR TITLE
refactor: compact schedule top bars

### DIFF
--- a/src/components/familjeschema/FamilySchedule.tsx
+++ b/src/components/familjeschema/FamilySchedule.tsx
@@ -349,6 +349,7 @@ export function FamilySchedule() {
         selectedYear={selectedYear}
         weekDates={weekDates}
         onNewActivity={() => { setEditingActivity(null); setModalOpen(true); }}
+        onOpenDataModal={() => setDataModalOpen(true)}
         onOpenSettings={() => setSettingsOpen(true)}
       />
       <FamilyBar
@@ -358,11 +359,11 @@ export function FamilySchedule() {
         onMemberClick={(id) => { setViewMode('layer'); setHighlightedMemberId(id); }}
       />
       <WeekNavigation
+        selectedWeek={selectedWeek}
         isCurrentWeek={isCurrentWeek}
         onNavigateWeek={navigateWeek}
         onGoToCurrentWeek={goToCurrentWeek}
         onToggleWeekPicker={() => setShowWeekPicker(!showWeekPicker)}
-        onOpenDataModal={() => setDataModalOpen(true)}
       />
       {showWeekPicker && (
         <WeekPicker

--- a/src/components/familjeschema/components/Header.tsx
+++ b/src/components/familjeschema/components/Header.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Plus, Settings } from 'lucide-react';
+import { Plus, Settings, ArrowRightLeft } from 'lucide-react';
 import { formatWeekRange } from '../utils/dateUtils';
 
 interface HeaderProps {
@@ -7,6 +7,7 @@ interface HeaderProps {
   selectedYear: number;
   weekDates: Date[];
   onNewActivity: () => void;
+  onOpenDataModal: () => void;
   onOpenSettings: () => void;
 }
 
@@ -15,38 +16,41 @@ export const Header: React.FC<HeaderProps> = ({
   selectedYear,
   weekDates,
   onNewActivity,
+  onOpenDataModal,
   onOpenSettings
 }) => {
   return (
-    <div className="header">
-      <div className="header-top">
-        <div className="logo-section">
-          <div className="logo-icon">📅</div>
-          <div>
-            <h1>Familjens Schema</h1>
-            <div className="week-info">
-              Vecka {selectedWeek} • {formatWeekRange(weekDates)} {selectedYear}
-            </div>
-          </div>
-        </div>
-
-        <div className="btn-group">
-          <button 
-            className="btn btn-primary" 
-            onClick={onNewActivity}
-            aria-label="Skapa ny aktivitet"
-          >
-            <Plus size={20}/> Ny Aktivitet
-          </button>
-          <button 
-            className="btn btn-warning" 
-            onClick={onOpenSettings}
-            aria-label="Öppna inställningar"
-          >
-            <Settings size={20}/> Inställningar
-          </button>
+    <header className="header">
+      <div>
+        <h1>Familjens Schema</h1>
+        <div className="week-info">
+          Vecka {selectedWeek} • {formatWeekRange(weekDates)} {selectedYear}
         </div>
       </div>
-    </div>
+
+      <div className="btn-group">
+        <button
+          className="btn btn-primary"
+          onClick={onNewActivity}
+          aria-label="Skapa ny aktivitet"
+        >
+          <Plus size={20}/> Ny Aktivitet
+        </button>
+        <button
+          className="btn btn-warning"
+          onClick={onOpenDataModal}
+          aria-label="Importera eller exportera data"
+        >
+          <ArrowRightLeft size={20}/> Import / Export
+        </button>
+        <button
+          className="btn btn-warning"
+          onClick={onOpenSettings}
+          aria-label="Öppna inställningar"
+        >
+          <Settings size={20}/> Inställningar
+        </button>
+      </div>
+    </header>
   );
 };

--- a/src/components/familjeschema/components/ScheduleGrid.tsx
+++ b/src/components/familjeschema/components/ScheduleGrid.tsx
@@ -46,21 +46,7 @@ export const ScheduleGrid: React.FC<ScheduleGridProps> = ({
   const monthAbbr = ['jan', 'feb', 'mar', 'apr', 'maj', 'jun',
                      'jul', 'aug', 'sep', 'okt', 'nov', 'dec'];
 
-  // Dynamically adjust column width based on overlap intensity
-  const columnWidths = days.map(day => {
-    const dayActivities = getActivitiesForDay(day);
-    const overlapGroups = calculateOverlapGroups(dayActivities);
-    const intensity = getOverlapIntensity(overlapGroups);
-    
-    switch(intensity) {
-      case 'high': return '2fr';
-      case 'medium': return '1.75fr';
-      case 'low': return '1.5fr';
-      default: return '1fr';
-    }
-  });
-
-  const gridTemplateColumns = `80px ${columnWidths.join(' ')}`;
+  const gridTemplateColumns = `72px repeat(${days.length}, minmax(140px, 1fr))`;
 
   // Helper function to get visual indicator for busy days
   const getDayIntensityClass = (day: string) => {
@@ -107,13 +93,13 @@ export const ScheduleGrid: React.FC<ScheduleGridProps> = ({
                   </span>
                 )}
               </div>
-              <div className="day-content" style={{ height: `${timeSlots.length * 60}px` }}>
+              <div className="day-content" style={{ height: `${timeSlots.length * 36}px` }}>
                 {overlapGroups.map((group, groupIndex) =>
                   group.map(activity => {
                     const { top, height } = calculatePosition(
                       activity.startTime,
                       activity.endTime,
-                      60,
+                      36,
                       settings.dayStart
                     );
                     

--- a/src/components/familjeschema/components/WeekNavigation.tsx
+++ b/src/components/familjeschema/components/WeekNavigation.tsx
@@ -1,67 +1,56 @@
 // src/components/WeekNavigation.tsx
 
 import React from 'react';
-import { ChevronLeft, ChevronRight, Calendar, Home, ArrowRightLeft } from 'lucide-react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
 
 interface WeekNavigationProps {
+  selectedWeek: number;
   isCurrentWeek: boolean;
   onNavigateWeek: (direction: number) => void;
   onGoToCurrentWeek: () => void;
   onToggleWeekPicker: () => void;
-  onOpenDataModal: () => void;
 }
 
 export const WeekNavigation: React.FC<WeekNavigationProps> = ({
+  selectedWeek,
   isCurrentWeek,
   onNavigateWeek,
   onGoToCurrentWeek,
-  onToggleWeekPicker,
-  onOpenDataModal
+  onToggleWeekPicker
 }) => {
   return (
     <nav className="week-nav" aria-label="Veckonavigering">
-      <div className="week-nav-content">
-        <div className="btn-group">
-          <button
-            className="btn btn-icon"
-            onClick={() => onNavigateWeek(-1)}
-            aria-label="Föregående vecka"
-          >
-            <ChevronLeft size={24}/>
-          </button>
-          <button
-            className={`btn ${isCurrentWeek ? 'btn-success' : ''}`}
-            onClick={onGoToCurrentWeek}
-            disabled={isCurrentWeek}
-            aria-label="Gå till nuvarande vecka"
-          >
-            <Home size={20}/> Denna Vecka
-          </button>
-          <button
-            className="btn btn-icon"
-            onClick={() => onNavigateWeek(1)}
-            aria-label="Nästa vecka"
-          >
-            <ChevronRight size={24}/>
-          </button>
-          <button
-            className="btn btn-info"
-            onClick={onToggleWeekPicker}
-            aria-label="Öppna veckoväljare"
-          >
-            <Calendar size={20}/> Välj Vecka
-          </button>
-        </div>
-
-        <div className="btn-group">
-           <button
-            className="btn btn-warning"
-            onClick={onOpenDataModal}
-           >
-            <ArrowRightLeft size={20} /> Import / Export
-          </button>
-        </div>
+      <div className="week-controls">
+        <button
+          className="btn btn-icon"
+          onClick={() => onNavigateWeek(-1)}
+          aria-label="Föregående vecka"
+        >
+          <ChevronLeft size={20}/>
+        </button>
+        <button
+          className="btn week-display"
+          onClick={onToggleWeekPicker}
+          aria-label="Öppna veckoväljare"
+        >
+          Vecka {selectedWeek}
+        </button>
+        <button
+          className="btn btn-icon"
+          onClick={() => onNavigateWeek(1)}
+          aria-label="Nästa vecka"
+        >
+          <ChevronRight size={20}/>
+        </button>
       </div>
+      <button
+        className="btn btn-link"
+        onClick={onGoToCurrentWeek}
+        disabled={isCurrentWeek}
+        aria-label="Gå till nuvarande vecka"
+      >
+        Denna vecka
+      </button>
     </nav>
   );
 };

--- a/src/components/familjeschema/styles/neobrutalism.css
+++ b/src/components/familjeschema/styles/neobrutalism.css
@@ -39,45 +39,25 @@ body {
 }
 
 .content-wrapper {
-  max-width: 1400px;
-  margin: 0 auto;
+  max-width: none;
+  margin: 0;
+  padding: 0 20px;
 }
 
 /* Header */
 .header {
+  position: sticky;
+  top: 0;
+  z-index: var(--z-header);
   background: var(--neo-white);
   border: 3px solid var(--neo-black);
-  padding: 30px;
-  margin-bottom: 30px;
   box-shadow: var(--shadow-lg);
-}
-
-.header-top {
   display: flex;
+  align-items: center;
   justify-content: space-between;
-  align-items: center;
-  margin-bottom: 25px;
-  flex-wrap: wrap;
-  gap: 20px;
-}
-
-.logo-section {
-  display: flex;
-  align-items: center;
-  gap: 20px;
-}
-
-.logo-icon {
-  width: 60px;
   height: 60px;
-  background: var(--neo-yellow);
-  border: 3px solid var(--neo-black);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 28px;
-  transform: rotate(-5deg);
-  box-shadow: var(--shadow-md);
+  padding: 0 16px;
+  margin-bottom: 8px;
 }
 
 h1 {
@@ -148,40 +128,63 @@ h1 {
 
 .btn-group {
   display: flex;
-  gap: 15px;
-  flex-wrap: wrap;
+  gap: 8px;
+  flex-wrap: nowrap;
 }
 
 /* Family Bar */
 .family-bar {
   background: var(--neo-white);
   border: 3px solid var(--neo-black);
-  padding: 20px;
-  margin-bottom: 25px;
+  padding: 4px 16px;
+  margin-bottom: 8px;
   display: flex;
-  justify-content: space-between;
   align-items: center;
+  gap: 8px;
   box-shadow: var(--shadow-md);
-  flex-wrap: wrap;
-  gap: 20px;
+  overflow-x: auto;
+  white-space: nowrap;
+  height: 40px;
 }
 
 .family-members {
   display: flex;
-  gap: 20px;
-  flex-wrap: wrap;
+  gap: 8px;
+  overflow-x: auto;
+  white-space: nowrap;
+  -webkit-overflow-scrolling: touch;
 }
 
 .member-badge {
   background: var(--neo-white);
   border: 2px solid var(--neo-black);
-  padding: 8px 16px;
-  display: flex;
+  padding: 4px 8px;
+  display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: 4px;
   font-weight: 700;
   box-shadow: 3px 3px 0 var(--neo-black);
   transition: .1s;
+  height: 32px;
+}
+
+.view-mode-toggle {
+  display: flex;
+  gap: 8px;
+  margin-left: auto;
+  height: 100%;
+}
+
+.view-mode-btn {
+  background: var(--neo-white);
+  border: 2px solid var(--neo-black);
+  padding: 4px 8px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-weight: 700;
+  box-shadow: 3px 3px 0 var(--neo-black);
+  height: 32px;
 }
 
 .member-badge:hover {
@@ -200,17 +203,35 @@ h1 {
 .week-nav {
   background: var(--neo-white);
   border: 3px solid var(--neo-black);
-  padding: 20px;
-  margin-bottom: 30px;
   box-shadow: var(--shadow-md);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 16px;
+  height: 44px;
+  margin-bottom: 8px;
 }
 
-.week-nav-content {
+.week-controls {
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  flex-wrap: wrap;
-  gap: 20px;
+  gap: 8px;
+}
+
+.week-display {
+  font-weight: 700;
+}
+
+.btn-link {
+  background: none;
+  border: none;
+  box-shadow: none;
+  padding: 0;
+  font-weight: 700;
+}
+
+.btn-link:disabled {
+  opacity: 0.5;
 }
 
 /* Week Picker */
@@ -302,45 +323,48 @@ h1 {
   border: 3px solid var(--neo-black);
   box-shadow: var(--shadow-xl);
   overflow: auto;
+  height: calc(100vh - 120px);
 }
 
 .schedule-grid {
   display: grid;
-  min-width: 1200px;
+  grid-template-columns: 72px repeat(7, minmax(140px, 1fr));
+  column-gap: 1px;
+  row-gap: 1px;
 }
 
 .time-column {
   background: var(--neo-yellow);
-  border-right: 3px solid var(--neo-black);
+  border-right: 1px solid var(--neo-black);
   position: sticky;
   left: 0;
   z-index: 10;
 }
 
 .time-header {
-  height: 80px;
-  border-bottom: 3px solid var(--neo-black);
+  height: 44px;
+  border-bottom: 1px solid var(--neo-black);
   display: flex;
   align-items: center;
   justify-content: center;
   font-weight: 700;
-  font-size: 1.2rem;
+  font-size: 1rem;
   background: var(--neo-purple);
   color: var(--neo-white);
 }
 
 .time-slot {
-  height: 60px;
-  border-bottom: 2px solid var(--neo-black);
+  height: 36px;
+  border-bottom: 1px solid var(--neo-black);
   display: flex;
   align-items: center;
   justify-content: center;
   font-weight: 700;
-  font-size: .9rem;
+  font-size: .8rem;
 }
 
 .day-column {
-  border-right: 2px solid var(--neo-black);
+  border-right: 1px solid var(--neo-black);
   position: relative;
   background: var(--neo-white);
 }
@@ -350,15 +374,17 @@ h1 {
 }
 
 .day-header {
-  height: 80px;
-  border-bottom: 3px solid var(--neo-black);
+  height: 44px;
+  border-bottom: 1px solid var(--neo-black);
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   font-weight: 700;
   background: var(--neo-cyan);
-  position: relative;
+  position: sticky;
+  top: 0;
+  z-index: 5;
   overflow: hidden;
 }
 
@@ -1349,7 +1375,7 @@ h1 {
 
 /* Adjust the main bar to space out members and view controls */
 .family-bar {
-  justify-content: space-between;
+  justify-content: flex-start;
   align-items: center;
 }
 


### PR DESCRIPTION
## Summary
- Compress schedule header with sticky layout and import/export button
- Consolidate week navigation controls and add compact styles
- Expand schedule grid with responsive columns and tighter cell sizing

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68c173bdbe5c8323980134bea9221c51