### PR TITLE
Refine family schedule header display

### DIFF
--- a/src/components/familjeschema/FamilySchedule.tsx
+++ b/src/components/familjeschema/FamilySchedule.tsx
@@ -343,7 +343,7 @@ export function FamilySchedule() {
         {/* Compact Header */}
         <div className="compact-header">
           <h1 className="compact-title">
-            Vecka {selectedWeek} • {formatWeekRange(weekDates)} {selectedYear}
+            {formatWeekRange(weekDates)} {selectedYear}
           </h1>
         </div>
 

--- a/src/components/familjeschema/components/Header.tsx
+++ b/src/components/familjeschema/components/Header.tsx
@@ -25,7 +25,7 @@ export const Header: React.FC<HeaderProps> = ({
           <div>
             <h1>Familjens Schema</h1>
             <div className="week-info">
-              Vecka {selectedWeek} • {formatWeekRange(weekDates)} {selectedYear}
+              {formatWeekRange(weekDates)} {selectedYear}
             </div>
           </div>
         </div>

--- a/src/components/familjeschema/components/ScheduleGrid.tsx
+++ b/src/components/familjeschema/components/ScheduleGrid.tsx
@@ -4,7 +4,6 @@ import React from 'react';
 import type { Activity, FamilyMember, Settings } from '../types';
 import { ActivityBlock } from './ActivityBlock';
 import { calculatePosition, calculateOverlapGroups } from '../utils/scheduleUtils';
-import { isToday } from '../utils/dateUtils';
 
 interface ScheduleGridProps {
   days: string[];
@@ -20,7 +19,7 @@ interface ScheduleGridProps {
 
 export const ScheduleGrid: React.FC<ScheduleGridProps> = ({
   days,
-  weekDates,
+  weekDates: _weekDates,
   timeSlots,
   activities,
   familyMembers,
@@ -43,8 +42,6 @@ export const ScheduleGrid: React.FC<ScheduleGridProps> = ({
     return 'high';
   };
 
-  const monthAbbr = ['jan', 'feb', 'mar', 'apr', 'maj', 'jun',
-                     'jul', 'aug', 'sep', 'okt', 'nov', 'dec'];
 
   // Dynamically adjust column width based on overlap intensity
   const columnWidths = days.map(day => {
@@ -86,27 +83,12 @@ export const ScheduleGrid: React.FC<ScheduleGridProps> = ({
 
         {/* Day columns */}
         {days.map((day, index) => {
-          const date = weekDates[index];
           const dayActivities = getActivitiesForDay(day);
           const overlapGroups = calculateOverlapGroups(dayActivities);
           const numColumns = overlapGroups.length;
-          const intensity = getOverlapIntensity(overlapGroups);
 
           return (
             <div key={day} className={`day-column ${getDayIntensityClass(day)}`}>
-              <div className={`day-header ${isToday(date) ? 'today' : ''}`}>
-                <span className="day-name">{day}</span>
-                <span className="day-date">
-                  {date.getDate()} {monthAbbr[date.getMonth()]}
-                </span>
-                {/* Add visual indicator for busy days */}
-                {intensity !== 'none' && (
-                  <span className={`intensity-indicator intensity-${intensity}`} 
-                        title={`${overlapGroups.length} overlapping activities`}>
-                    {intensity === 'high' ? '🔥' : intensity === 'medium' ? '⚡' : '📌'}
-                  </span>
-                )}
-              </div>
               <div className="day-content" style={{ height: `${timeSlots.length * 60}px` }}>
                 {overlapGroups.map((group, groupIndex) =>
                   group.map(activity => {


### PR DESCRIPTION
## Summary
- Remove daily header row from ScheduleGrid
- Show date range and year without "Vecka" in main header
- Mirror simplified date range in compact header

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68c3f15624a88323ad4cc9011ac91a0e