### PR TITLE
Remove week range headers from family schedule

### DIFF
--- a/src/components/familjeschema/FamilySchedule.tsx
+++ b/src/components/familjeschema/FamilySchedule.tsx
@@ -11,7 +11,7 @@ import type {
   CreateActivityPayload,
 } from './types';
 import { WEEKDAYS_FULL, ALL_DAYS } from './constants';
-import { getWeekNumber, getWeekDateRange, isWeekInPast, isWeekInFuture, formatWeekRange } from './utils/dateUtils';
+import { getWeekNumber, getWeekDateRange, isWeekInPast, isWeekInFuture } from './utils/dateUtils';
 import { generateTimeSlots } from './utils/scheduleUtils';
 import { downloadAllICS } from './utils/exportUtils';
 import { useFocusTrap } from './hooks/useFocusTrap';
@@ -342,9 +342,7 @@ export function FamilySchedule() {
       <div className="schedule-main-content">
         {/* Compact Header */}
         <div className="compact-header">
-          <h1 className="compact-title">
-            {formatWeekRange(weekDates)} {selectedYear}
-          </h1>
+          <h1 className="compact-title">Familjens Schema</h1>
         </div>
 
         {/* Notifications */}

--- a/src/components/familjeschema/components/Header.tsx
+++ b/src/components/familjeschema/components/Header.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Plus, Settings } from 'lucide-react';
-import { formatWeekRange } from '../utils/dateUtils';
 
 interface HeaderProps {
   selectedWeek: number;
@@ -24,9 +23,7 @@ export const Header: React.FC<HeaderProps> = ({
           <div className="logo-icon">📅</div>
           <div>
             <h1>Familjens Schema</h1>
-            <div className="week-info">
-              {formatWeekRange(weekDates)} {selectedYear}
-            </div>
+            {/* Date range removed */}
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- Drop week range display from main header
- Show only title in compact header

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68c3f68d7e5c8323a7b07c993db5dedf