### PR TITLE
feat: manage family members in settings

### DIFF
--- a/src/components/familjeschema/components/FamilyMemberEditor.tsx
+++ b/src/components/familjeschema/components/FamilyMemberEditor.tsx
@@ -1,0 +1,110 @@
+import React, { useState } from 'react';
+import { ACTIVITY_COLORS } from '../constants';
+import type { FamilyMember } from '../types';
+import { IconPicker } from './IconPicker';
+
+interface FamilyMemberEditorProps {
+  member?: FamilyMember;
+  existingNames: string[];
+  onSave: (member: { name: string; color: string; icon: string }) => void | Promise<void>;
+  onCancel: () => void;
+}
+
+export const FamilyMemberEditor: React.FC<FamilyMemberEditorProps> = ({
+  member,
+  existingNames,
+  onSave,
+  onCancel,
+}) => {
+  const [name, setName] = useState(member?.name || '');
+  const [color, setColor] = useState(member?.color || ACTIVITY_COLORS[0]);
+  const [icon, setIcon] = useState(member?.icon || '👤');
+  const [showPicker, setShowPicker] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) {
+      setError('Namn krävs');
+      return;
+    }
+    if (existingNames.includes(name) && name !== member?.name) {
+      setError('Namnet finns redan');
+      return;
+    }
+    if (!color) {
+      setError('Välj en färg');
+      return;
+    }
+    setError(null);
+    setSaving(true);
+    await onSave({ name: name.trim(), color, icon });
+    setSaving(false);
+  };
+
+  return (
+    <form className="member-editor-form" onSubmit={handleSubmit}>
+      <div className="form-group">
+        <label className="form-label">Namn</label>
+        <input
+          className="form-input"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        {error && <p className="form-error">{error}</p>}
+      </div>
+
+      <div className="form-group">
+        <label className="form-label">Färg</label>
+        <div style={{ display: 'flex', gap: '5px', flexWrap: 'wrap' }}>
+          {ACTIVITY_COLORS.map((c) => (
+            <button
+              type="button"
+              key={c}
+              style={{
+                background: c,
+                width: '24px',
+                height: '24px',
+                border: '2px solid var(--neo-black)',
+                cursor: 'pointer',
+              }}
+              onClick={() => setColor(c)}
+            />
+          ))}
+          <input
+            type="color"
+            value={color}
+            onChange={(e) => setColor(e.target.value)}
+          />
+        </div>
+      </div>
+
+      <div className="form-group">
+        <label className="form-label">Ikon</label>
+        <button
+          type="button"
+          className="btn"
+          onClick={() => setShowPicker(true)}
+        >
+          {icon}
+        </button>
+        {showPicker && (
+          <IconPicker
+            onSelect={(i) => setIcon(i)}
+            onClose={() => setShowPicker(false)}
+          />
+        )}
+      </div>
+
+      <div className="member-actions" style={{ justifyContent: 'flex-end' }}>
+        <button type="button" className="btn" onClick={onCancel}>
+          Avbryt
+        </button>
+        <button type="submit" className="btn btn-success" disabled={saving}>
+          {saving ? 'Sparar...' : 'Spara'}
+        </button>
+      </div>
+    </form>
+  );
+};

--- a/src/components/familjeschema/components/FamilyMemberEditor.tsx
+++ b/src/components/familjeschema/components/FamilyMemberEditor.tsx
@@ -25,22 +25,39 @@ export const FamilyMemberEditor: React.FC<FamilyMemberEditorProps> = ({
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!name.trim()) {
+
+    const trimmed = name.trim();
+    if (!trimmed) {
       setError('Namn krävs');
       return;
     }
-    if (existingNames.includes(name) && name !== member?.name) {
+
+    // Case-insensitive duplicate check; allow unchanged when editing
+    const existsCI = existingNames.some(
+      (n) => n.trim().toLowerCase() === trimmed.toLowerCase()
+    );
+    const unchanged =
+      member && member.name.trim().toLowerCase() === trimmed.toLowerCase();
+
+    if (existsCI && !unchanged) {
       setError('Namnet finns redan');
       return;
     }
+
     if (!color) {
       setError('Välj en färg');
       return;
     }
+
     setError(null);
     setSaving(true);
-    await onSave({ name: name.trim(), color, icon });
-    setSaving(false);
+    try {
+      await onSave({ name: trimmed, color, icon });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Kunde inte spara medlem.');
+    } finally {
+      setSaving(false);
+    }
   };
 
   return (

--- a/src/components/familjeschema/components/FamilyMembersList.tsx
+++ b/src/components/familjeschema/components/FamilyMembersList.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import type { FamilyMember, Activity } from '../types';
+
+interface FamilyMembersListProps {
+  members: FamilyMember[];
+  activities: Activity[];
+  onEdit: (member: FamilyMember) => void;
+  onDelete: (member: FamilyMember) => void;
+}
+
+export const FamilyMembersList: React.FC<FamilyMembersListProps> = ({
+  members,
+  activities,
+  onEdit,
+  onDelete,
+}) => {
+  const getUsage = (id: string) =>
+    activities.filter((a) => a.participants.includes(id)).length;
+
+  const handleDelete = (member: FamilyMember) => {
+    const count = getUsage(member.id);
+    const confirmMsg =
+      count > 0
+        ? `Är du säker? Medlemmen används i ${count} aktiviteter.`
+        : 'Är du säker på att du vill ta bort medlemmen?';
+    if (window.confirm(confirmMsg)) {
+      onDelete(member);
+    }
+  };
+
+  return (
+    <ul>
+      {members.map((m) => (
+        <li key={m.id} className="member-list-item">
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <span
+              className="member-color-preview"
+              style={{ background: m.color }}
+            />
+            <span>{m.icon} {m.name}</span>
+          </div>
+          <div className="member-actions">
+            <span style={{ marginRight: '10px' }}>{getUsage(m.id)}</span>
+            <button className="btn" onClick={() => onEdit(m)}>
+              Redigera
+            </button>
+            <button
+              className="member-delete-btn"
+              onClick={() => handleDelete(m)}
+            >
+              Ta bort
+            </button>
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+};

--- a/src/components/familjeschema/components/SettingsModal.tsx
+++ b/src/components/familjeschema/components/SettingsModal.tsx
@@ -1,18 +1,46 @@
-import { forwardRef } from 'react';
-import { X, Save } from 'lucide-react';
-import type { Settings } from '../types';
+import { forwardRef, useState } from 'react';
+import { X, Save, Plus } from 'lucide-react';
+import type { Settings, FamilyMember, Activity } from '../types';
 import { SizableModal } from './SizableModal';
+import { FamilyMemberEditor } from './FamilyMemberEditor';
+import { FamilyMembersList } from './FamilyMembersList';
 
 interface SettingsModalProps {
   isOpen: boolean;
   settings: Settings;
+  familyMembers: FamilyMember[];
+  activities: Activity[];
+  memberFormOpen: boolean;
+  editingMember: FamilyMember | null;
   onClose: () => void;
   onSettingsChange: (settings: Settings) => void;
+  onEditMember: (member: FamilyMember | null) => void;
+  onSaveMember: (member: { name: string; color: string; icon: string }) => void;
+  onDeleteMember: (member: FamilyMember) => void;
+  onCloseMemberForm: () => void;
 }
 
 export const SettingsModal = forwardRef<HTMLDivElement, SettingsModalProps>(
-  ({ isOpen, settings, onClose, onSettingsChange }, ref) => {
-    const handleSave = () => {
+  (
+    {
+      isOpen,
+      settings,
+      familyMembers,
+      activities,
+      memberFormOpen,
+      editingMember,
+      onClose,
+      onSettingsChange,
+      onEditMember,
+      onSaveMember,
+      onDeleteMember,
+      onCloseMemberForm,
+    },
+    ref
+  ) => {
+    const [activeTab, setActiveTab] = useState<'settings' | 'members'>('settings');
+
+    const handleSaveSettings = () => {
       onClose();
     };
 
@@ -25,67 +53,135 @@ export const SettingsModal = forwardRef<HTMLDivElement, SettingsModalProps>(
         ref={ref}
       >
         <div className="modal-header">
-          <h2 id="settings-title" className="modal-title">Inställningar</h2>
+          <h2 id="settings-title" className="modal-title">
+            Inställningar
+          </h2>
           <button
             className="modal-close"
             onClick={onClose}
             aria-label="Stäng inställningar"
           >
-            <X size={24}/>
+            <X size={24} />
+          </button>
+        </div>
+
+        <div className="data-modal-tabs">
+          <button
+            className={`tab-btn ${activeTab === 'settings' ? 'active' : ''}`}
+            onClick={() => setActiveTab('settings')}
+          >
+            Schema
+          </button>
+          <button
+            className={`tab-btn ${activeTab === 'members' ? 'active' : ''}`}
+            onClick={() => setActiveTab('members')}
+          >
+            Familjemedlemmar
           </button>
         </div>
 
         <div className="modal-body">
-          {/* Weekends */}
-          <div className="form-group">
-            <label className="form-label">Arbetsdagar</label>
-            <label className="checkbox-label">
-              <input
-                type="checkbox"
-                className="checkbox-input"
-                checked={settings.showWeekends}
-                onChange={e => onSettingsChange({ ...settings, showWeekends: e.target.checked })}
-                aria-label="Inkludera helger"
-              />
-              Inkludera lör/sön
-            </label>
-          </div>
+          {activeTab === 'settings' && (
+            <>
+              {/* Weekends */}
+              <div className="form-group">
+                <label className="form-label">Arbetsdagar</label>
+                <label className="checkbox-label">
+                  <input
+                    type="checkbox"
+                    className="checkbox-input"
+                    checked={settings.showWeekends}
+                    onChange={(e) =>
+                      onSettingsChange({
+                        ...settings,
+                        showWeekends: e.target.checked,
+                      })
+                    }
+                    aria-label="Inkludera helger"
+                  />
+                  Inkludera lör/sön
+                </label>
+              </div>
 
-          {/* Hour range */}
-          <div className="form-group">
-            <label className="form-label">Tidsintervall (start–slut)</label>
-            <div style={{ display: 'flex', gap: '10px' }}>
-              <input
-                type="number"
-                className="form-input"
-                value={settings.dayStart}
-                min="0"
-                max="23"
-                onChange={e => onSettingsChange({ ...settings, dayStart: Number(e.target.value) })}
-                aria-label="Starttimme"
-              />
-              <input
-                type="number"
-                className="form-input"
-                value={settings.dayEnd}
-                min={settings.dayStart + 1}
-                max="23"
-                onChange={e => onSettingsChange({ ...settings, dayEnd: Number(e.target.value) })}
-                aria-label="Sluttimme"
-              />
-            </div>
-          </div>
+              {/* Hour range */}
+              <div className="form-group">
+                <label className="form-label">Tidsintervall (start–slut)</label>
+                <div style={{ display: 'flex', gap: '10px' }}>
+                  <input
+                    type="number"
+                    className="form-input"
+                    value={settings.dayStart}
+                    min="0"
+                    max="23"
+                    onChange={(e) =>
+                      onSettingsChange({
+                        ...settings,
+                        dayStart: Number(e.target.value),
+                      })
+                    }
+                    aria-label="Starttimme"
+                  />
+                  <input
+                    type="number"
+                    className="form-input"
+                    value={settings.dayEnd}
+                    min={settings.dayStart + 1}
+                    max="23"
+                    onChange={(e) =>
+                      onSettingsChange({
+                        ...settings,
+                        dayEnd: Number(e.target.value),
+                      })
+                    }
+                    aria-label="Sluttimme"
+                  />
+                </div>
+              </div>
+            </>
+          )}
+
+          {activeTab === 'members' && (
+            <>
+              {memberFormOpen ? (
+                <FamilyMemberEditor
+                  member={editingMember || undefined}
+                  existingNames={familyMembers.map((m) => m.name)}
+                  onSave={onSaveMember}
+                  onCancel={onCloseMemberForm}
+                />
+              ) : (
+                <>
+                  <FamilyMembersList
+                    members={familyMembers}
+                    activities={activities}
+                    onEdit={(m) => onEditMember(m)}
+                    onDelete={(m) => onDeleteMember(m)}
+                  />
+                  <div style={{ marginTop: '15px', textAlign: 'right' }}>
+                    <button
+                      className="btn btn-primary"
+                      onClick={() => onEditMember(null)}
+                    >
+                      <Plus size={18} /> Lägg till medlem
+                    </button>
+                  </div>
+                </>
+              )}
+            </>
+          )}
         </div>
 
-        <div className="modal-footer">
-          <button
-            className="btn btn-success"
-            onClick={handleSave}
-            aria-label="Spara inställningar"
-          >
-            <Save size={20}/> Spara
-          </button>
-        </div>
+        {activeTab === 'settings' && (
+          <div className="modal-footer">
+            <button
+              className="btn btn-success"
+              onClick={handleSaveSettings}
+              aria-label="Spara inställningar"
+            >
+              <Save size={20} /> Spara
+            </button>
+          </div>
+        )}
       </SizableModal>
     );
   }

--- a/src/components/familjeschema/styles/neobrutalism.css
+++ b/src/components/familjeschema/styles/neobrutalism.css
@@ -1816,3 +1816,40 @@ button.member-badge:hover {
   max-height: calc(100vh - 200px);
   overflow: auto;
 }
+
+/* Family member editor */
+.member-editor-form {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+}
+
+.member-list-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  border: 2px solid var(--neo-black);
+  margin-bottom: 8px;
+  background: var(--neo-white);
+}
+
+.member-color-preview {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  border: 2px solid var(--neo-black);
+}
+
+.member-delete-btn {
+  background: var(--neo-red);
+  color: var(--neo-black);
+  border: 2px solid var(--neo-black);
+  padding: 4px 8px;
+}
+
+.member-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}

--- a/src/services/scheduleService.ts
+++ b/src/services/scheduleService.ts
@@ -98,7 +98,45 @@ export const scheduleService = {
     return data.data || [];
   },
 
-  // ... (funktioner för att skapa/uppdatera/ta bort familjemedlemmar kan läggas till här)
+  async createFamilyMember(member: { name: string; color: string; icon: string }): Promise<FamilyMember> {
+    const response = await fetchWithAuth(`${SCHEDULE_API_URL}/family-members`, {
+      method: 'POST',
+      body: JSON.stringify(member),
+    });
+    if (!response.ok) throw new Error('Failed to create family member');
+    const data = await response.json();
+    return data.data;
+  },
+
+  async updateFamilyMember(
+    id: string,
+    updates: Partial<{ name: string; color: string; icon: string }>
+  ): Promise<FamilyMember> {
+    const response = await fetchWithAuth(`${SCHEDULE_API_URL}/family-members/${id}`, {
+      method: 'PUT',
+      body: JSON.stringify(updates),
+    });
+    if (!response.ok) throw new Error('Failed to update family member');
+    const data = await response.json();
+    return data.data;
+  },
+
+  async deleteFamilyMember(id: string): Promise<void> {
+    const response = await fetchWithAuth(`${SCHEDULE_API_URL}/family-members/${id}`, {
+      method: 'DELETE',
+    });
+    if (!response.ok) throw new Error('Failed to delete family member');
+  },
+
+  async reorderFamilyMembers(memberIds: string[]): Promise<FamilyMember[]> {
+    const response = await fetchWithAuth(`${SCHEDULE_API_URL}/family-members/reorder`, {
+      method: 'POST',
+      body: JSON.stringify({ order: memberIds }),
+    });
+    if (!response.ok) throw new Error('Failed to reorder family members');
+    const data = await response.json();
+    return data.data || [];
+  },
 
   // --- Inställningar ---
   async getSettings(): Promise<Settings> {

--- a/src/services/scheduleService.ts
+++ b/src/services/scheduleService.ts
@@ -125,7 +125,16 @@ export const scheduleService = {
     const response = await fetchWithAuth(`${SCHEDULE_API_URL}/family-members/${id}`, {
       method: 'DELETE',
     });
-    if (!response.ok) throw new Error('Failed to delete family member');
+    if (!response.ok) {
+      let msg = 'Kunde inte ta bort medlem.';
+      try {
+        const data = await response.json();
+        if (data?.error) msg = data.error;
+      } catch {
+        // keep default msg
+      }
+      throw new Error(msg);
+    }
   },
 
   async reorderFamilyMembers(memberIds: string[]): Promise<FamilyMember[]> {


### PR DESCRIPTION
## Summary
- extend schedule service with create, update, delete and reorder family member operations
- add FamilyMemberEditor and FamilyMembersList components
- include family member management tab in SettingsModal and wiring in FamilySchedule
- style new member management UI

## Testing
- `npm run lint`
- `npm run build` *(fails: Module not found for emoji-picker-react, @radix-ui/react-* packages)*

------
https://chatgpt.com/codex/tasks/task_e_68c41b3a66808323a0b8c9185621d412