### PR TITLE
Fix icon picker overflow in FamilyMemberEditor

### DIFF
--- a/src/components/familjeschema/components/FamilyMemberEditor.tsx
+++ b/src/components/familjeschema/components/FamilyMemberEditor.tsx
@@ -99,19 +99,22 @@ export const FamilyMemberEditor: React.FC<FamilyMemberEditorProps> = ({
 
       <div className="form-group">
         <label className="form-label">Ikon</label>
-        <button
-          type="button"
-          className="btn"
-          onClick={() => setShowPicker(true)}
-        >
-          {icon}
-        </button>
-        {showPicker && (
-          <IconPicker
-            onSelect={(i) => setIcon(i)}
-            onClose={() => setShowPicker(false)}
-          />
-        )}
+        <div style={{ position: 'relative', display: 'inline-block' }}>
+          <button
+            type="button"
+            className="btn"
+            onClick={() => setShowPicker(true)}
+          >
+            {icon}
+          </button>
+          {showPicker && (
+            <IconPicker
+              placement="right"
+              onSelect={(i) => setIcon(i)}
+              onClose={() => setShowPicker(false)}
+            />
+          )}
+        </div>
       </div>
 
       <div className="member-actions" style={{ justifyContent: 'flex-end' }}>

--- a/src/components/familjeschema/components/IconPicker.tsx
+++ b/src/components/familjeschema/components/IconPicker.tsx
@@ -5,16 +5,17 @@ import type { EmojiClickData } from 'emoji-picker-react';
 interface IconPickerProps {
   onSelect: (icon: string) => void;
   onClose: () => void;
+  placement?: 'bottom' | 'right';
 }
 
-export const IconPicker: React.FC<IconPickerProps> = ({ onSelect, onClose }) => {
+export const IconPicker: React.FC<IconPickerProps> = ({ onSelect, onClose, placement = 'bottom' }) => {
   const handleEmojiClick = (emojiData: EmojiClickData) => {
     onSelect(emojiData.emoji);
     onClose();
   };
 
   return (
-    <div className="icon-picker-popover">
+    <div className={`icon-picker-popover${placement === 'right' ? ' icon-picker-right' : ''}`}>
       <div className="icon-picker-header">
         <h4>Välj en ikon</h4>
         <button onClick={onClose} className="modal-close" style={{ width: '30px', height: '30px' }}>×</button>

--- a/src/components/familjeschema/styles/neobrutalism.css
+++ b/src/components/familjeschema/styles/neobrutalism.css
@@ -711,6 +711,13 @@ h1 {
   padding: 15px;
 }
 
+.icon-picker-popover.icon-picker-right {
+  top: 0;
+  left: 100%;
+  margin-top: 0;
+  margin-left: 10px;
+}
+
 .icon-picker-header {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
## Summary
- allow configuring IconPicker placement
- show IconPicker to the right in FamilyMemberEditor to keep it in view
- add CSS for right-opening IconPicker

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7d0730608832389e47f4b441e3d57