### PR TITLE
feat: add Twemoji fallback for emojis

### DIFF
--- a/src/components/familjeschema/components/ActivityBlock.tsx
+++ b/src/components/familjeschema/components/ActivityBlock.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef } from 'react';
 import type { Activity, FamilyMember } from '../types';
 import { HoverCard } from './HoverCard';
+import { Emoji } from '@/utils/Emoji';
 
 interface ActivityBlockProps {
   activity: Activity;
@@ -113,7 +114,7 @@ export const ActivityBlock: React.FC<ActivityBlockProps> = ({
         onKeyDown={handleKeyDown}
       >
         <div className="activity-name">
-          <span>{activity.icon}</span>
+          <Emoji emoji={activity.icon} />
           {activity.name}
         </div>
         <div className="activity-time">
@@ -121,7 +122,9 @@ export const ActivityBlock: React.FC<ActivityBlockProps> = ({
         </div>
         <div className="activity-participants">
           {participants.map(p => (
-            <span key={p.id} aria-label={p.name}>{p.icon}</span>
+            <span key={p.id} aria-label={p.name}>
+              <Emoji emoji={p.icon} />
+            </span>
           ))}
         </div>
       </div>

--- a/src/components/familjeschema/components/ActivityModal.tsx
+++ b/src/components/familjeschema/components/ActivityModal.tsx
@@ -4,6 +4,7 @@ import type { FormData, FamilyMember, Activity } from '../types';
 import { SizableModal } from './SizableModal';
 import { ACTIVITY_COLORS } from '../constants';
 import { IconPicker } from './IconPicker';
+import { Emoji } from '@/utils/Emoji';
 import {
   Dialog,
   DialogContent,
@@ -113,7 +114,7 @@ export const ActivityModal = forwardRef<HTMLDivElement, ActivityModalProps>(
                 aria-label="Välj ikon"
                 style={{ fontSize: '1.5rem', width: '60px', height: 'auto' }}
               >
-                {formData.icon}
+                <Emoji emoji={formData.icon} />
               </button>
               <input
                 id="activity-name"
@@ -184,7 +185,7 @@ export const ActivityModal = forwardRef<HTMLDivElement, ActivityModalProps>(
                     }
                   }}
                 >
-                  <span>{member.icon}</span>
+                  <Emoji emoji={member.icon} />
                   <span>{member.name}</span>
                 </div>
               ))}

--- a/src/components/familjeschema/components/FamilyBar.tsx
+++ b/src/components/familjeschema/components/FamilyBar.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { FamilyMember } from '../types';
 import { Grid3x3, Layers } from 'lucide-react';
+import { Emoji } from '@/utils/Emoji';
 
 interface FamilyBarProps {
   members: FamilyMember[];
@@ -21,7 +22,7 @@ export const FamilyBar: React.FC<FamilyBarProps> = ({ members, viewMode, onSetVi
             aria-label={`Visa ${member.name}s schema i lagervy`}
             title={`Visa ${member.name}s schema i lagervy`}
           >
-            <span role="img" aria-hidden="true">{member.icon}</span>
+            <Emoji emoji={member.icon} />
             <span className="member-dot" style={{ background: member.color }}></span>
             <span>{member.name}</span>
           </button>

--- a/src/components/familjeschema/components/FamilyMemberEditor.tsx
+++ b/src/components/familjeschema/components/FamilyMemberEditor.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { ACTIVITY_COLORS } from '../constants';
 import type { FamilyMember } from '../types';
 import { IconPicker } from './IconPicker';
+import { Emoji } from '@/utils/Emoji';
 
 interface FamilyMemberEditorProps {
   member?: FamilyMember;
@@ -100,12 +101,8 @@ export const FamilyMemberEditor: React.FC<FamilyMemberEditorProps> = ({
       <div className="form-group">
         <label className="form-label">Ikon</label>
         <div style={{ position: 'relative', display: 'inline-block' }}>
-          <button
-            type="button"
-            className="btn"
-            onClick={() => setShowPicker(true)}
-          >
-            {icon}
+          <button type="button" className="btn" onClick={() => setShowPicker(true)}>
+            <Emoji emoji={icon} />
           </button>
           {showPicker && (
             <IconPicker

--- a/src/components/familjeschema/components/FamilyMembersList.tsx
+++ b/src/components/familjeschema/components/FamilyMembersList.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { FamilyMember, Activity } from '../types';
+import { Emoji } from '@/utils/Emoji';
 
 interface FamilyMembersListProps {
   members: FamilyMember[];
@@ -37,7 +38,9 @@ export const FamilyMembersList: React.FC<FamilyMembersListProps> = ({
               className="member-color-preview"
               style={{ background: m.color }}
             />
-            <span>{m.icon} {m.name}</span>
+            <span>
+              <Emoji emoji={m.icon} /> {m.name}
+            </span>
           </div>
           <div className="member-actions">
             <span style={{ marginRight: '10px' }}>{getUsage(m.id)}</span>

--- a/src/components/familjeschema/components/HoverCard.tsx
+++ b/src/components/familjeschema/components/HoverCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { Activity, FamilyMember } from '../types';
+import { Emoji } from '@/utils/Emoji';
 
 interface HoverCardProps {
   activity: Activity;
@@ -18,7 +19,7 @@ export const HoverCard: React.FC<HoverCardProps> = ({ activity, familyMembers, p
   return (
     <div className={`hover-card ${positionClasses} ${visibilityClass}`}>
       <div className="hover-card-header">
-        <span className="hover-card-icon">{activity.icon}</span>
+        <span className="hover-card-icon"><Emoji emoji={activity.icon} /></span>
         <h3 className="hover-card-title">{activity.name}</h3>
       </div>
       <div className="hover-card-body">
@@ -30,7 +31,7 @@ export const HoverCard: React.FC<HoverCardProps> = ({ activity, familyMembers, p
             <div className="participants-list">
               {participants.map(p => (
                 <span key={p.id} className="participant-badge">
-                  {p.icon} {p.name}
+                  <Emoji emoji={p.icon} /> {p.name}
                 </span>
               ))}
             </div>

--- a/src/components/familjeschema/components/LayerView.tsx
+++ b/src/components/familjeschema/components/LayerView.tsx
@@ -3,6 +3,7 @@ import type { Activity, FamilyMember, Settings } from '../types';
 import { ActivityBlock } from './ActivityBlock';
 import { calculatePosition } from '../utils/scheduleUtils';
 import { isToday } from '../utils/dateUtils';
+import { Emoji } from '@/utils/Emoji';
 
 interface LayerViewProps {
   days: string[];
@@ -101,7 +102,7 @@ export const LayerView: React.FC<LayerViewProps> = ({
               {/* Member info column */}
               <div className="member-info" style={{ background: member.color + '20' }}>
                 <div className="member-avatar">
-                  <span className="member-icon">{member.icon}</span>
+                  <span className="member-icon"><Emoji emoji={member.icon} /></span>
                   <div className="member-details">
                     <span className="member-name">{member.name}</span>
                     <span className="activity-count">

--- a/src/components/familjeschema/components/Sidebar.tsx
+++ b/src/components/familjeschema/components/Sidebar.tsx
@@ -1,11 +1,11 @@
 import React, { useState } from 'react';
-import { 
-  Calendar, 
-  ChevronLeft, 
-  ChevronRight, 
-  Home, 
-  Plus, 
-  Settings, 
+import {
+  Calendar,
+  ChevronLeft,
+  ChevronRight,
+  Home,
+  Plus,
+  Settings,
   ArrowRightLeft,
   Menu,
   X,
@@ -13,6 +13,7 @@ import {
   Layers
 } from 'lucide-react';
 import type { FamilyMember } from '../types';
+import { Emoji } from '@/utils/Emoji';
 
 interface SidebarProps {
   familyMembers: FamilyMember[];
@@ -118,7 +119,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
                 title={member.name}
                 style={{ borderLeftColor: member.color }}
               >
-                <span className="member-icon">{member.icon}</span>
+                <span className="member-icon"><Emoji emoji={member.icon} /></span>
                 {!isCollapsed && (
                   <>
                     <span className="member-name">{member.name}</span>

--- a/src/components/familjeschema/styles/neobrutalism.css
+++ b/src/components/familjeschema/styles/neobrutalism.css
@@ -1860,3 +1860,10 @@ button.member-badge:hover {
   align-items: center;
   gap: 8px;
 }
+/* Twemoji fallback img ska bete sig som text */
+.emoji-img {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  vertical-align: -0.15em; /* lite neddrag så den ligger snyggt på baslinjen */
+}

--- a/src/utils/Emoji.tsx
+++ b/src/utils/Emoji.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+
+function toCodePointSequence(str: string): string {
+  const cps: string[] = [];
+  for (const ch of Array.from(str)) {
+    const cp = ch.codePointAt(0);
+    if (cp !== undefined) cps.push(cp.toString(16));
+  }
+  return cps.join("-");
+}
+
+/**
+ * Heuristik: använd Twemoji för "komplexa" emoji (ZWJ/VS/skin tones),
+ * annars lita på native rendering.
+ */
+function shouldUseTwemoji(emoji: string): boolean {
+  if (!emoji) return false;
+  // zero-width joiner eller variation selector
+  if(/[\u200D\uFE0F]/.test(emoji)) return true;
+
+  // hudtoner (U+1F3FB..U+1F3FF)
+  for (const ch of Array.from(emoji)) {
+    const cp = ch.codePointAt(0)!;
+    if (cp >= 0x1f3fb && cp <= 0x1f3ff) return true;
+  }
+
+  // längre än ett code point => ofta kombinerad emoji
+  const cps = Array.from(emoji);
+  return cps.length > 1;
+}
+
+type EmojiProps = {
+  emoji: string;
+  className?: string;
+  title?: string;
+  // tvinga Twemoji även om enkel (t.ex. för konsekvens i UI)
+  forceTwemoji?: boolean;
+};
+
+export const Emoji: React.FC<EmojiProps> = ({ emoji, className, title, forceTwemoji }) => {
+  if (!emoji) return null;
+
+  const useTw = forceTwemoji || shouldUseTwemoji(emoji);
+  if (!useTw) {
+    return (
+      <span className={className} title={title} aria-label={emoji}>
+        {emoji}
+      </span>
+    );
+  }
+
+  const seq = toCodePointSequence(emoji);
+  // Stabil källa för SVG: jsDelivr mirror av Twemoji
+  const src = `https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/svg/${seq}.svg`;
+
+  return (
+    <img
+      className={className ? `${className} emoji-img` : "emoji-img"}
+      src={src}
+      alt={emoji}
+      title={title || emoji}
+      loading="lazy"
+      decoding="async"
+      draggable={false}
+    />
+  );
+};
+


### PR DESCRIPTION
## Summary
- add `Emoji` component to render native or Twemoji fallback depending on sequence complexity
- style `.emoji-img` to align Twemoji SVGs with text
- use `Emoji` across family schedule components for member and activity icons

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68c82bbf88b08323a6ef5214b23c9903