### PR TITLE
feat: add Twemoji fallback rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "react-fast-marquee": "^1.6.4",
     "react-resizable-panels": "^2.1.7",
     "tailwind-merge": "^2.3.0",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "twemoji": "14.0.2"
   },
   "devDependencies": {
     "@faker-js/faker": "^8.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@3.4.3)
+      twemoji:
+        specifier: 14.0.2
+        version: 14.0.2
     devDependencies:
       '@faker-js/faker':
         specifier: ^8.4.1
@@ -1482,6 +1485,10 @@ packages:
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
 
+  fs-extra@8.1.0:
+    resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
+    engines: {node: '>=6 <7 || >=8'}
+
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
@@ -1753,6 +1760,12 @@ packages:
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
     hasBin: true
+
+  jsonfile@4.0.0:
+    resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
+
+  jsonfile@5.0.0:
+    resolution: {integrity: sha512-NQRZ5CRo74MhMMC3/3r5g2k4fjodJ/wh8MxjFbCViWKFjxrnudWSY5vomh+23ZaXzAS7J3fBZIR2dV6WbmfM0w==}
 
   jspdf@3.0.0:
     resolution: {integrity: sha512-QvuQZvOI8CjfjVgtajdL0ihrDYif1cN5gXiF9lb9Pd9JOpmocvnNyFO9sdiJ/8RA5Bu8zyGOUjJLj5kiku16ug==}
@@ -2396,6 +2409,12 @@ packages:
   tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
 
+  twemoji-parser@14.0.0:
+    resolution: {integrity: sha512-9DUOTGLOWs0pFWnh1p6NF+C3CkQ96PWmEFwhOVmT3WbecRC+68AIqpsnJXygfkFcp4aXbOp8Dwbhh/HQgvoRxA==}
+
+  twemoji@14.0.2:
+    resolution: {integrity: sha512-BzOoXIe1QVdmsUmZ54xbEH+8AgtOKUiG53zO5vVP2iUu6h5u9lN15NcuS6te4OY96qx0H7JK9vjjl9WQbkTRuA==}
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -2430,6 +2449,10 @@ packages:
 
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
+  universalify@0.1.2:
+    resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
+    engines: {node: '>= 4.0.0'}
 
   update-browserslist-db@1.1.2:
     resolution: {integrity: sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg==}
@@ -3986,6 +4009,12 @@ snapshots:
 
   fraction.js@4.3.7: {}
 
+  fs-extra@8.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 4.0.0
+      universalify: 0.1.2
+
   fs.realpath@1.0.0: {}
 
   fsevents@2.3.3:
@@ -4261,6 +4290,16 @@ snapshots:
   json5@1.0.2:
     dependencies:
       minimist: 1.2.8
+
+  jsonfile@4.0.0:
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
+  jsonfile@5.0.0:
+    dependencies:
+      universalify: 0.1.2
+    optionalDependencies:
+      graceful-fs: 4.2.11
 
   jspdf@3.0.0:
     dependencies:
@@ -4885,6 +4924,15 @@ snapshots:
 
   tslib@2.6.2: {}
 
+  twemoji-parser@14.0.0: {}
+
+  twemoji@14.0.2:
+    dependencies:
+      fs-extra: 8.1.0
+      jsonfile: 5.0.0
+      twemoji-parser: 14.0.0
+      universalify: 0.1.2
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -4933,6 +4981,8 @@ snapshots:
       which-boxed-primitive: 1.0.2
 
   undici-types@5.26.5: {}
+
+  universalify@0.1.2: {}
 
   update-browserslist-db@1.1.2(browserslist@4.24.4):
     dependencies:

--- a/src/components/familjeschema/components/LayerView.tsx
+++ b/src/components/familjeschema/components/LayerView.tsx
@@ -162,7 +162,7 @@ export const LayerView: React.FC<LayerViewProps> = ({
                               <ActivityBlock {...activityBlockProps} />
                               {isShared && (
                                 <div className="shared-indicator" title="Delad aktivitet">
-                                  👥
+                                  <Emoji emoji="👥" forceTwemoji />
                                 </div>
                               )}
                             </div>

--- a/src/components/familjeschema/components/Sidebar.tsx
+++ b/src/components/familjeschema/components/Sidebar.tsx
@@ -63,7 +63,9 @@ export const Sidebar: React.FC<SidebarProps> = ({
 
         {/* Logo Section */}
         <div className="sidebar-logo">
-          <div className="logo-icon-small">📅</div>
+          <div className="logo-icon-small">
+            <Emoji emoji="📅" forceTwemoji />
+          </div>
           {!isCollapsed && <span className="logo-text">Familjens Schema</span>}
         </div>
 

--- a/src/components/familjeschema/styles/neobrutalism.css
+++ b/src/components/familjeschema/styles/neobrutalism.css
@@ -1865,5 +1865,5 @@ button.member-badge:hover {
   display: inline-block;
   width: 1em;
   height: 1em;
-  vertical-align: -0.15em; /* lite neddrag så den ligger snyggt på baslinjen */
+  vertical-align: -0.15em;
 }

--- a/src/utils/Emoji.tsx
+++ b/src/utils/Emoji.tsx
@@ -1,68 +1,69 @@
-import React from "react";
-
-function toCodePointSequence(str: string): string {
-  const cps: string[] = [];
-  for (const ch of Array.from(str)) {
-    const cp = ch.codePointAt(0);
-    if (cp !== undefined) cps.push(cp.toString(16));
-  }
-  return cps.join("-");
-}
-
-/**
- * Heuristik: använd Twemoji för "komplexa" emoji (ZWJ/VS/skin tones),
- * annars lita på native rendering.
- */
-function shouldUseTwemoji(emoji: string): boolean {
-  if (!emoji) return false;
-  // zero-width joiner eller variation selector
-  if(/[\u200D\uFE0F]/.test(emoji)) return true;
-
-  // hudtoner (U+1F3FB..U+1F3FF)
-  for (const ch of Array.from(emoji)) {
-    const cp = ch.codePointAt(0)!;
-    if (cp >= 0x1f3fb && cp <= 0x1f3ff) return true;
-  }
-
-  // längre än ett code point => ofta kombinerad emoji
-  const cps = Array.from(emoji);
-  return cps.length > 1;
-}
+import React, { useMemo, useState } from "react";
+import twemoji from "twemoji";
 
 type EmojiProps = {
   emoji: string;
   className?: string;
   title?: string;
-  // tvinga Twemoji även om enkel (t.ex. för konsekvens i UI)
+  // Använd Twemoji även för enkla emoji (för konsekvens)
   forceTwemoji?: boolean;
 };
 
-export const Emoji: React.FC<EmojiProps> = ({ emoji, className, title, forceTwemoji }) => {
-  if (!emoji) return null;
+const TW_VERSION = "14.0.2";
+const HOSTS = [
+  `https://cdn.jsdelivr.net/gh/twitter/twemoji@${TW_VERSION}/assets/svg/`,
+  `https://cdnjs.cloudflare.com/ajax/libs/twemoji/${TW_VERSION}/svg/`,
+  `https://unpkg.com/twemoji@${TW_VERSION}/assets/svg/`,
+];
 
-  const useTw = forceTwemoji || shouldUseTwemoji(emoji);
-  if (!useTw) {
+function shouldUseTwemoji(emoji: string): boolean {
+  if (!emoji) return false;
+  // ZWJ/variation selector → kombinationsemoji
+  if (/[\u200D\uFE0F]/.test(emoji)) return true;
+  // Hudtoner U+1F3FB..U+1F3FF
+  for (const ch of Array.from(emoji)) {
+    const cp = ch.codePointAt(0)!;
+    if (cp >= 0x1f3fb && cp <= 0x1f3ff) return true;
+  }
+  // Fler än ett code point → sannolikt kombination
+  return Array.from(emoji).length > 1;
+}
+
+export const Emoji: React.FC<EmojiProps> = ({ emoji, className, title, forceTwemoji }) => {
+  const clean = (emoji || "").trim();
+  const useTw = forceTwemoji || shouldUseTwemoji(clean);
+  const seq = useMemo(() => (useTw ? twemoji.convert.toCodePoint(clean) : ""), [useTw, clean]);
+
+  const [hostIdx, setHostIdx] = useState(0);
+  const [failed, setFailed] = useState(false);
+
+  if (!clean) return null;
+
+  // Fallback till native om vi inte ska/kan använda Twemoji
+  if (!useTw || failed) {
     return (
-      <span className={className} title={title} aria-label={emoji}>
-        {emoji}
+      <span className={className} title={title} aria-label={clean}>
+        {clean}
       </span>
     );
   }
 
-  const seq = toCodePointSequence(emoji);
-  // Stabil källa för SVG: jsDelivr mirror av Twemoji
-  const src = `https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/svg/${seq}.svg`;
+  const src = `${HOSTS[Math.min(hostIdx, HOSTS.length - 1)]}${seq}.svg`;
 
   return (
     <img
       className={className ? `${className} emoji-img` : "emoji-img"}
       src={src}
-      alt={emoji}
-      title={title || emoji}
+      alt={clean}
+      title={title || clean}
       loading="lazy"
       decoding="async"
       draggable={false}
+      referrerPolicy="no-referrer"
+      onError={() => {
+        if (hostIdx < HOSTS.length - 1) setHostIdx(i => i + 1);
+        else setFailed(true); // sista fallback: native
+      }}
     />
   );
 };
-


### PR DESCRIPTION
## Summary
- add twemoji dependency and shared Emoji component with CDN fallback for complex emoji
- ensure sidebar and layer view use the new Emoji component and add styling for rendered svg icons

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68c85b7846dc8323a508bb8f7f98fdd3