### PR TITLE
Use custom codepoint conversion for Emoji component

### DIFF
--- a/src/utils/Emoji.tsx
+++ b/src/utils/Emoji.tsx
@@ -1,5 +1,4 @@
 import React, { useMemo, useState } from "react";
-import twemoji from "twemoji";
 
 type EmojiProps = {
   emoji: string;
@@ -21,7 +20,10 @@ function shouldUseTwemoji(s: string): boolean {
 export const Emoji: React.FC<EmojiProps> = ({ emoji, className, title, forceTwemoji }) => {
   const clean = (emoji || "").trim();
   const useTw = forceTwemoji || shouldUseTwemoji(clean);
-  const code = useMemo(() => (useTw ? twemoji.convert.toCodePoint(clean) : ""), [useTw, clean]);
+  const code = useMemo(
+    () => (useTw ? Array.from(clean).map((c) => c.codePointAt(0)!.toString(16)).join("-") : ""),
+    [useTw, clean]
+  );
   const [failed, setFailed] = useState(false);
 
   if (!clean) return null;


### PR DESCRIPTION
## Summary
- replace the Emoji component's use of twemoji.convert.toCodePoint with a local code point converter
- ensure the computed code matches self-hosted @twemoji/svg asset paths while keeping the dependency available

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68c87bd54aa08323b30cc8d767bb7ccb