### PR TITLE
Enlarge FamilySchedule settings modal

### DIFF
--- a/src/components/familjeschema/components/SettingsModal.tsx
+++ b/src/components/familjeschema/components/SettingsModal.tsx
@@ -49,7 +49,9 @@ export const SettingsModal = forwardRef<HTMLDivElement, SettingsModalProps>(
         isOpen={isOpen}
         onClose={onClose}
         storageKey="settings-modal"
-        initialSize="small"
+        initialSize="full"
+        forcedSize="full"
+        enableSizeControls={false}
         ref={ref}
       >
         <div className="modal-header">

--- a/src/components/familjeschema/components/SizableModal.tsx
+++ b/src/components/familjeschema/components/SizableModal.tsx
@@ -1,7 +1,7 @@
-import React, { forwardRef, useRef } from 'react';
+import React, { forwardRef, useEffect, useRef } from 'react';
 import type { ReactNode } from 'react';
 import { useSizable, type ModalSize } from '../hooks/useSizable';
-import { Square, StretchHorizontal, StretchVertical } from 'lucide-react';
+import { Square, StretchHorizontal, StretchVertical, Maximize2 } from 'lucide-react';
 
 interface SizableModalProps {
   children: ReactNode;
@@ -9,6 +9,8 @@ interface SizableModalProps {
   onClose: () => void;
   storageKey: string;
   initialSize?: ModalSize;
+  forcedSize?: ModalSize;
+  enableSizeControls?: boolean;
 }
 
 export const SizableModal = forwardRef<HTMLDivElement, SizableModalProps>(
@@ -17,13 +19,21 @@ export const SizableModal = forwardRef<HTMLDivElement, SizableModalProps>(
     isOpen,
     onClose,
     storageKey,
-    initialSize = 'medium'
+    initialSize = 'medium',
+    forcedSize,
+    enableSizeControls = true
   }, ref) => {
 
     const modalRef = useRef<HTMLDivElement>(null);
     React.useImperativeHandle(ref, () => modalRef.current as HTMLDivElement);
 
     const { currentSize, setSize } = useSizable(modalRef as React.RefObject<HTMLElement>, { storageKey, initialSize });
+
+    useEffect(() => {
+      if (forcedSize && currentSize !== forcedSize) {
+        setSize(forcedSize);
+      }
+    }, [forcedSize, currentSize, setSize]);
 
     if (!isOpen) return null;
 
@@ -35,6 +45,7 @@ export const SizableModal = forwardRef<HTMLDivElement, SizableModalProps>(
         { size: 'small', icon: <Square size={18}/>, label: 'Liten' },
         { size: 'medium', icon: <StretchHorizontal size={18}/>, label: 'Medium' },
         { size: 'large', icon: <StretchVertical size={18}/>, label: 'Stor' },
+        { size: 'full', icon: <Maximize2 size={18}/>, label: 'Jättestor' },
     ];
 
     return (
@@ -47,19 +58,21 @@ export const SizableModal = forwardRef<HTMLDivElement, SizableModalProps>(
           ref={modalRef}
         >
           {/* Size Controls */}
-          <div className="modal-size-controls">
-            {sizeButtons.map(({ size, icon, label }) => (
-              <button
-                key={size}
-                className={`btn-size ${currentSize === size ? 'active' : ''}`}
-                onClick={() => setSize(size)}
-                aria-label={`Byt till ${label} storlek`}
-                title={label}
-              >
-                {icon}
-              </button>
-            ))}
-          </div>
+          {enableSizeControls && (
+            <div className="modal-size-controls">
+              {sizeButtons.map(({ size, icon, label }) => (
+                <button
+                  key={size}
+                  className={`btn-size ${currentSize === size ? 'active' : ''}`}
+                  onClick={() => setSize(size)}
+                  aria-label={`Byt till ${label} storlek`}
+                  title={label}
+                >
+                  {icon}
+                </button>
+              ))}
+            </div>
+          )}
 
           {children}
         </div>

--- a/src/components/familjeschema/hooks/useSizable.ts
+++ b/src/components/familjeschema/hooks/useSizable.ts
@@ -2,12 +2,13 @@ import { useEffect, useCallback } from 'react';
 import type { RefObject } from 'react';
 import { useLocalStorage } from './useLocalStorage';
 
-export type ModalSize = 'small' | 'medium' | 'large';
+export type ModalSize = 'small' | 'medium' | 'large' | 'full';
 
 export const MODAL_SIZES: Record<ModalSize, { width: string; height: string }> = {
   small: { width: '450px', height: '550px' },
   medium: { width: '650px', height: '650px' },
   large: { width: '850px', height: '750px' },
+  full: { width: 'min(75vw, 1200px)', height: 'min(75vh, 900px)' },
 };
 
 interface UseSizableOptions {


### PR DESCRIPTION
## Summary
- force the FamilySchedule settings modal to open at a larger 75% viewport size
- extend the sizable modal to support a forced size, hide the resize controls, and add a new full option

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca831073c08323a3f7512ca921b22d