### PR TITLE
Ensure sizable modal dimensions apply on mount

### DIFF
--- a/src/components/familjeschema/hooks/useSizable.ts
+++ b/src/components/familjeschema/hooks/useSizable.ts
@@ -1,4 +1,4 @@
-import { useEffect, useCallback } from 'react';
+import { useEffect } from 'react';
 import type { RefObject } from 'react';
 import { useLocalStorage } from './useLocalStorage';
 
@@ -23,19 +23,24 @@ export const useSizable = (
   const { storageKey, initialSize = 'medium' } = options;
   const [size, setSize] = useLocalStorage<ModalSize>(`sizable-${storageKey}`, initialSize);
 
-  const applySize = useCallback(() => {
-    if (ref.current) {
-      const { width, height } = MODAL_SIZES[size];
-      ref.current.style.width = width;
-      ref.current.style.height = height;
-    }
-  }, [ref, size]);
+  const element = ref.current;
 
   useEffect(() => {
+    if (!element) return;
+
+    const applySize = () => {
+      const { width, height } = MODAL_SIZES[size];
+      element.style.width = width;
+      element.style.height = height;
+    };
+
     applySize();
     window.addEventListener('resize', applySize);
-    return () => window.removeEventListener('resize', applySize);
-  }, [size, applySize]);
+
+    return () => {
+      window.removeEventListener('resize', applySize);
+    };
+  }, [element, size]);
 
   return {
     currentSize: size,


### PR DESCRIPTION
## Summary
- rework the sizable hook to reapply width and height whenever the modal element mounts
- keep the resize listener tied to the current modal node so forced sizes apply immediately

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca8850479c8323b00aa2b73822cce0