### PR TITLE
Remove sidebar logo section

### DIFF
--- a/src/components/familjeschema/components/Sidebar.tsx
+++ b/src/components/familjeschema/components/Sidebar.tsx
@@ -121,12 +121,6 @@ export const Sidebar: React.FC<SidebarProps> = ({
           {isCollapsed ? <ChevronRight size={20} /> : <ChevronLeft size={20} />}
         </button>
 
-        {/* Logo Section */}
-        <div className="sidebar-logo">
-          <div className="logo-icon-small">📅</div>
-          {!isCollapsed && <span className="logo-text">Familjens Schema</span>}
-        </div>
-
         {/* Week Navigation */}
         <div className="sidebar-section">
           {!isCollapsed && <h3 className="sidebar-heading">VECKA</h3>}


### PR DESCRIPTION
## Summary
- remove the sidebar logo block from the Familjeschema sidebar component to simplify the layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca8e35572c83238261101e2851f67b