### PR TITLE
Add AI schedule import normalization pipeline

### DIFF
--- a/src/components/familjeschema/components/AIAssistantTab.tsx
+++ b/src/components/familjeschema/components/AIAssistantTab.tsx
@@ -1,0 +1,78 @@
+import { useState } from 'react';
+
+import { scheduleService } from '@/services/scheduleService';
+import type { ActivityImportItem } from '@/types/schedule';
+import { normalizeActivitiesForBackend } from '@/utils/normalizeActivities';
+
+interface AIAssistantTabProps {
+  selectedWeek: number;
+  selectedYear: number;
+  onPreview: (
+    ok: ActivityImportItem[],
+    errors: { index: number; message: string }[],
+  ) => void;
+}
+
+export function AIAssistantTab({ selectedWeek, selectedYear, onPreview }: AIAssistantTabProps) {
+  const [naturalInput, setNaturalInput] = useState('');
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleParse = async () => {
+    const text = naturalInput.trim();
+    if (!text) return;
+
+    setIsProcessing(true);
+    setError(null);
+    try {
+      const aiItems = await scheduleService.parseScheduleWithAI(text, selectedWeek, selectedYear);
+      const { ok, errors } = normalizeActivitiesForBackend(aiItems, selectedWeek, selectedYear);
+      onPreview(ok, errors);
+
+      if (!ok.length) {
+        setError(errors[0]?.message || 'AI gav inga giltiga aktiviteter.');
+        return;
+      }
+
+      if (errors.length) {
+        setError('Vissa rader kunde inte tolkas. Se detaljerna nedan.');
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Kunde inte tolka texten.');
+      onPreview([], []);
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="form-group">
+        <label htmlFor="ai-freeform" className="form-label">
+          Beskriv veckan med naturligt språk
+        </label>
+        <textarea
+          id="ai-freeform"
+          className="form-textarea"
+          rows={6}
+          value={naturalInput}
+          onChange={(event) => setNaturalInput(event.target.value)}
+          placeholder="T.ex. Måndag 18:00-19:00 simning för Rut..."
+        />
+      </div>
+      <div className="flex items-center gap-3">
+        <button
+          className="btn btn-success"
+          onClick={handleParse}
+          disabled={isProcessing || !naturalInput.trim()}
+        >
+          {isProcessing ? 'Tolkar…' : 'Tolka med AI'}
+        </button>
+        <span className="text-sm text-gray-600">
+          Aktuell vecka: {selectedWeek}, år {selectedYear}
+        </span>
+      </div>
+      {error && <p className="text-sm text-red-600">{error}</p>}
+    </div>
+  );
+}

--- a/src/components/familjeschema/components/DataModal.tsx
+++ b/src/components/familjeschema/components/DataModal.tsx
@@ -1,7 +1,11 @@
 // src/components/DataModal.tsx
 
 import React, { useState } from 'react';
-import { X, Upload, FileText, Download } from 'lucide-react';
+import { X, Upload, FileText, Download, Sparkles } from 'lucide-react';
+
+import type { ActivityImportItem } from '@/types/schedule';
+
+import { AIAssistantTab } from './AIAssistantTab';
 
 interface DataModalProps {
   isOpen: boolean;
@@ -10,11 +14,39 @@ interface DataModalProps {
   onTextImport: (jsonText: string) => void;
   onExportJSON: () => void;
   onExportICS: () => void;
+  selectedWeek: number;
+  selectedYear: number;
+  onAIPreview: (
+    ok: ActivityImportItem[],
+    errors: { index: number; message: string }[],
+  ) => void;
+  aiPreviewActivities: ActivityImportItem[];
+  aiPreviewErrors: { index: number; message: string }[];
+  aiParticipantWarnings: string[];
+  onAIImport: () => void;
+  aiImporting: boolean;
+  aiImportError: string | null;
 }
 
-export const DataModal: React.FC<DataModalProps> = ({ isOpen, onClose, onFileImport, onTextImport, onExportJSON, onExportICS }) => {
+export const DataModal: React.FC<DataModalProps> = ({
+  isOpen,
+  onClose,
+  onFileImport,
+  onTextImport,
+  onExportJSON,
+  onExportICS,
+  selectedWeek,
+  selectedYear,
+  onAIPreview,
+  aiPreviewActivities,
+  aiPreviewErrors,
+  aiParticipantWarnings,
+  onAIImport,
+  aiImporting,
+  aiImportError,
+}) => {
   const [jsonText, setJsonText] = useState('');
-  const [activeTab, setActiveTab] = useState<'paste' | 'file' | 'export'>('paste');
+  const [activeTab, setActiveTab] = useState<'paste' | 'file' | 'export' | 'ai'>('ai');
 
   if (!isOpen) {
     return null;
@@ -27,17 +59,126 @@ export const DataModal: React.FC<DataModalProps> = ({ isOpen, onClose, onFileImp
     }
   };
 
+  const renderAIPreview = () => {
+    const hasPreview = aiPreviewActivities.length > 0;
+    return (
+      <div className="space-y-3">
+        <AIAssistantTab
+          selectedWeek={selectedWeek}
+          selectedYear={selectedYear}
+          onPreview={onAIPreview}
+        />
+
+        {aiPreviewErrors.length > 0 && (
+          <div
+            style={{
+              backgroundColor: '#fff7ed',
+              border: '1px solid #fb923c',
+              borderRadius: '8px',
+              padding: '12px',
+            }}
+          >
+            <p className="form-label" style={{ marginBottom: '0.5rem' }}>
+              Några rader kunde inte importeras:
+            </p>
+            <ul className="text-sm" style={{ marginLeft: '1rem' }}>
+              {aiPreviewErrors.map((error, idx) => (
+                <li key={`${error.index}-${idx}`}>
+                  Rad {error.index + 1}: {error.message}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {aiParticipantWarnings.length > 0 && (
+          <div
+            style={{
+              backgroundColor: '#f0f9ff',
+              border: '1px solid #38bdf8',
+              borderRadius: '8px',
+              padding: '12px',
+            }}
+          >
+            <p className="form-label" style={{ marginBottom: '0.5rem' }}>
+              Okända deltagare hittades. De importeras som fritext:
+            </p>
+            <p className="text-sm">{aiParticipantWarnings.join(', ')}</p>
+          </div>
+        )}
+
+        {aiImportError && (
+          <pre
+            className="text-sm"
+            style={{
+              color: '#dc2626',
+              backgroundColor: '#fef2f2',
+              borderRadius: '8px',
+              padding: '8px',
+              whiteSpace: 'pre-wrap',
+            }}
+          >
+            {aiImportError}
+          </pre>
+        )}
+
+        {hasPreview && (
+          <div className="ai-preview-table" style={{ maxHeight: '220px', overflowY: 'auto' }}>
+            <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+              <thead>
+                <tr>
+                  <th style={{ textAlign: 'left', borderBottom: '1px solid #ccc', padding: '6px' }}>Namn</th>
+                  <th style={{ textAlign: 'left', borderBottom: '1px solid #ccc', padding: '6px' }}>Tid</th>
+                  <th style={{ textAlign: 'left', borderBottom: '1px solid #ccc', padding: '6px' }}>Dag(ar)</th>
+                  <th style={{ textAlign: 'left', borderBottom: '1px solid #ccc', padding: '6px' }}>Vecka</th>
+                  <th style={{ textAlign: 'left', borderBottom: '1px solid #ccc', padding: '6px' }}>År</th>
+                  <th style={{ textAlign: 'left', borderBottom: '1px solid #ccc', padding: '6px' }}>Deltagare</th>
+                </tr>
+              </thead>
+              <tbody>
+                {aiPreviewActivities.map((activity, idx) => (
+                  <tr key={`${activity.name}-${idx}`}>
+                    <td style={{ padding: '6px', borderBottom: '1px solid #eee' }}>{activity.name}</td>
+                    <td style={{ padding: '6px', borderBottom: '1px solid #eee' }}>
+                      {activity.startTime} – {activity.endTime}
+                    </td>
+                    <td style={{ padding: '6px', borderBottom: '1px solid #eee' }}>
+                      {(activity.days || []).join(', ')}
+                    </td>
+                    <td style={{ padding: '6px', borderBottom: '1px solid #eee' }}>{activity.week}</td>
+                    <td style={{ padding: '6px', borderBottom: '1px solid #eee' }}>{activity.year}</td>
+                    <td style={{ padding: '6px', borderBottom: '1px solid #eee' }}>
+                      {activity.participants.join(', ')}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    );
+  };
+
   return (
     <div className="modal-overlay" onClick={onClose}>
-      <div className="modal" style={{ width: '600px' }} onClick={e => e.stopPropagation()}>
+      <div className="modal" style={{ width: '640px' }} onClick={(event) => event.stopPropagation()}>
         <div className="modal-header">
-          <h2 id="data-modal-title" className="modal-title">Importera / Exportera Data</h2>
+          <h2 id="data-modal-title" className="modal-title">
+            Importera / Exportera Data
+          </h2>
           <button className="modal-close" onClick={onClose} aria-label="Stäng modal">
             <X size={24} />
           </button>
         </div>
 
         <div className="data-modal-tabs">
+          <button
+            className={`tab-btn ${activeTab === 'ai' ? 'active' : ''}`}
+            onClick={() => setActiveTab('ai')}
+          >
+            <Sparkles size={18} /> AI-assistent
+          </button>
           <button
             className={`tab-btn ${activeTab === 'paste' ? 'active' : ''}`}
             onClick={() => setActiveTab('paste')}
@@ -50,7 +191,7 @@ export const DataModal: React.FC<DataModalProps> = ({ isOpen, onClose, onFileImp
           >
             <Upload size={18} /> Ladda upp Fil
           </button>
-           <button
+          <button
             className={`tab-btn ${activeTab === 'export' ? 'active' : ''}`}
             onClick={() => setActiveTab('export')}
           >
@@ -59,6 +200,8 @@ export const DataModal: React.FC<DataModalProps> = ({ isOpen, onClose, onFileImp
         </div>
 
         <div className="modal-body">
+          {activeTab === 'ai' && renderAIPreview()}
+
           {activeTab === 'paste' && (
             <div className="form-group">
               <label htmlFor="json-paste-area" className="form-label">
@@ -70,28 +213,30 @@ export const DataModal: React.FC<DataModalProps> = ({ isOpen, onClose, onFileImp
                 className="form-textarea"
                 placeholder="[{...}]"
                 value={jsonText}
-                onChange={e => setJsonText(e.target.value)}
+                onChange={(event) => setJsonText(event.target.value)}
               />
             </div>
           )}
 
           {activeTab === 'file' && (
             <div className="form-group" style={{ textAlign: 'center', padding: '40px 0' }}>
-               <label className="btn btn-primary" style={{ display: 'inline-flex' }}>
-                  <Upload size={20} /> Välj JSON-fil
-                  <input
-                    type="file"
-                    accept=".json"
-                    style={{ display: 'none' }}
-                    onChange={onFileImport}
-                  />
-                </label>
+              <label className="btn btn-primary" style={{ display: 'inline-flex' }}>
+                <Upload size={20} /> Välj JSON-fil
+                <input
+                  type="file"
+                  accept=".json"
+                  style={{ display: 'none' }}
+                  onChange={onFileImport}
+                />
+              </label>
             </div>
           )}
 
           {activeTab === 'export' && (
             <div className="form-group" style={{ textAlign: 'center', padding: '20px 0' }}>
-              <p className="form-label" style={{ marginBottom: '20px' }}>Ladda ner all schemadata i önskat format.</p>
+              <p className="form-label" style={{ marginBottom: '20px' }}>
+                Ladda ner all schemadata i önskat format.
+              </p>
               <div className="btn-group" style={{ justifyContent: 'center' }}>
                 <button className="btn btn-success" onClick={onExportJSON}>
                   <Download size={20} /> Exportera som JSON
@@ -105,7 +250,9 @@ export const DataModal: React.FC<DataModalProps> = ({ isOpen, onClose, onFileImp
         </div>
 
         <div className="modal-footer">
-          <button className="btn" onClick={onClose}>Avbryt</button>
+          <button className="btn" onClick={onClose}>
+            Avbryt
+          </button>
           {activeTab === 'paste' && (
             <button
               className="btn btn-success"
@@ -113,6 +260,15 @@ export const DataModal: React.FC<DataModalProps> = ({ isOpen, onClose, onFileImp
               disabled={!jsonText.trim()}
             >
               Importera text
+            </button>
+          )}
+          {activeTab === 'ai' && aiPreviewActivities.length > 0 && (
+            <button
+              className="btn btn-success"
+              onClick={onAIImport}
+              disabled={aiImporting}
+            >
+              {aiImporting ? 'Importerar…' : `Importera ${aiPreviewActivities.length} aktiviteter`}
             </button>
           )}
         </div>

--- a/src/types/schedule.ts
+++ b/src/types/schedule.ts
@@ -1,0 +1,26 @@
+export type SwedishDay =
+  | 'Måndag'
+  | 'Tisdag'
+  | 'Onsdag'
+  | 'Torsdag'
+  | 'Fredag'
+  | 'Lördag'
+  | 'Söndag';
+
+export type ActivityImportItem = {
+  name: string;
+  icon?: string;
+  startTime: string;
+  endTime: string;
+  participants: string[];
+  days?: SwedishDay[];
+  week?: number;
+  year?: number;
+  date?: string;
+  dates?: string[];
+  location?: string;
+  notes?: string;
+  color?: string;
+  seriesId?: string;
+  recurringEndDate?: string;
+};

--- a/src/utils/dateSv.ts
+++ b/src/utils/dateSv.ts
@@ -1,0 +1,62 @@
+import type { SwedishDay } from '@/types/schedule';
+
+export const SV_DAYS: SwedishDay[] = [
+  'Måndag',
+  'Tisdag',
+  'Onsdag',
+  'Torsdag',
+  'Fredag',
+  'Lördag',
+  'Söndag',
+];
+
+export const SV_FROM_ISO: Record<number, SwedishDay> = {
+  1: 'Måndag',
+  2: 'Tisdag',
+  3: 'Onsdag',
+  4: 'Torsdag',
+  5: 'Fredag',
+  6: 'Lördag',
+  7: 'Söndag',
+};
+
+export function isoWeekYear(input: string | Date): { week: number; year: number } {
+  const d = input instanceof Date ? new Date(input) : new Date(`${input}T00:00:00Z`);
+  if (Number.isNaN(d.getTime())) {
+    throw new Error(`Invalid date: ${input}`);
+  }
+  const tmp = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+  const dayNum = tmp.getUTCDay() === 0 ? 7 : tmp.getUTCDay();
+  tmp.setUTCDate(tmp.getUTCDate() + 4 - dayNum);
+  const year = tmp.getUTCFullYear();
+  const yearStart = new Date(Date.UTC(year, 0, 1));
+  const week = Math.ceil((((+tmp - +yearStart) / 86400000) + 1) / 7);
+  return { week, year };
+}
+
+export function isoWeekday(input: string | Date): 1 | 2 | 3 | 4 | 5 | 6 | 7 {
+  const d = input instanceof Date ? new Date(input) : new Date(`${input}T00:00:00Z`);
+  if (Number.isNaN(d.getTime())) {
+    throw new Error(`Invalid date: ${input}`);
+  }
+  const day = d.getUTCDay();
+  return (day === 0 ? 7 : day) as 1 | 2 | 3 | 4 | 5 | 6 | 7;
+}
+
+export function swedishDayFromDate(input: string | Date): SwedishDay {
+  return SV_FROM_ISO[isoWeekday(input)];
+}
+
+export function dateFromISOWeek(
+  year: number,
+  week: number,
+  isoWeekday: 1 | 2 | 3 | 4 | 5 | 6 | 7,
+): Date {
+  const simple = new Date(Date.UTC(year, 0, 1 + (week - 1) * 7));
+  const dow = simple.getUTCDay() || 7;
+  const monday = new Date(simple);
+  monday.setUTCDate(simple.getUTCDate() - dow + 1);
+  const result = new Date(monday);
+  result.setUTCDate(monday.getUTCDate() + (isoWeekday - 1));
+  return result;
+}

--- a/src/utils/normalizeActivities.ts
+++ b/src/utils/normalizeActivities.ts
@@ -59,7 +59,9 @@ export function normalizeActivitiesForBackend(
       const color = (raw as { color?: unknown })?.color;
       const baseSeriesId = String((raw as { seriesId?: unknown })?.seriesId ?? uuid());
 
-      const rawDates = ensureArray<string>((raw as { dates?: unknown })?.dates);
+      const rawDates = ensureArray((raw as { dates?: unknown })?.dates).map((value) =>
+        String(value),
+      );
       const singleDate = (raw as { date?: unknown })?.date;
 
       const pushWeekObject = (week: number, year: number, days: SwedishDay[]) => {

--- a/src/utils/normalizeActivities.ts
+++ b/src/utils/normalizeActivities.ts
@@ -1,0 +1,154 @@
+import type { ActivityImportItem, SwedishDay } from '@/types/schedule';
+import { normalizeHHMM, isStartBeforeEnd } from './time';
+import { isoWeekYear, swedishDayFromDate, dateFromISOWeek } from './dateSv';
+import { normalizeSwedishDay } from './strings';
+
+function ensureArray<T>(value: T | T[] | undefined, fallback: T[] = []): T[] {
+  if (value == null) return fallback;
+  return Array.isArray(value) ? value : [value];
+}
+
+function uuid(): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
+function isoWeekdayFromSwedish(day: SwedishDay): 1 | 2 | 3 | 4 | 5 | 6 | 7 {
+  const index = ['Måndag', 'Tisdag', 'Onsdag', 'Torsdag', 'Fredag', 'Lördag', 'Söndag'].indexOf(day);
+  return (index + 1) as 1 | 2 | 3 | 4 | 5 | 6 | 7;
+}
+
+export function normalizeActivitiesForBackend(
+  rawItems: unknown[],
+  uiWeek?: number,
+  uiYear?: number,
+): { ok: ActivityImportItem[]; errors: { index: number; message: string }[] } {
+  const ok: ActivityImportItem[] = [];
+  const errors: { index: number; message: string }[] = [];
+
+  rawItems.forEach((raw, index) => {
+    try {
+      const name = String((raw as { name?: unknown })?.name ?? '').trim();
+      if (!name) throw new Error('name is required');
+
+      const startTime = normalizeHHMM(String((raw as { startTime?: unknown })?.startTime ?? ''));
+      const endTime = normalizeHHMM(String((raw as { endTime?: unknown })?.endTime ?? ''));
+      if (!isStartBeforeEnd(startTime, endTime)) {
+        throw new Error('startTime must be earlier than endTime');
+      }
+
+      const rawParticipants = (raw as { participants?: unknown })?.participants;
+      let participants: string[];
+      if (Array.isArray(rawParticipants)) {
+        participants = rawParticipants.map((p) => String(p));
+      } else if (rawParticipants == null) {
+        participants = [];
+      } else {
+        participants = [String(rawParticipants)];
+      }
+
+      const icon = (raw as { icon?: unknown })?.icon;
+      const location = (raw as { location?: unknown })?.location;
+      const notes = (raw as { notes?: unknown })?.notes;
+      const color = (raw as { color?: unknown })?.color;
+      const baseSeriesId = String((raw as { seriesId?: unknown })?.seriesId ?? uuid());
+
+      const rawDates = ensureArray<string>((raw as { dates?: unknown })?.dates);
+      const singleDate = (raw as { date?: unknown })?.date;
+
+      const pushWeekObject = (week: number, year: number, days: SwedishDay[]) => {
+        if (!Number.isInteger(week) || !Number.isInteger(year)) {
+          throw new Error('week/year must be integers');
+        }
+        if (!days.length) throw new Error('days is required');
+
+        const recurringEndDate = (raw as { recurringEndDate?: unknown })?.recurringEndDate;
+        if (recurringEndDate != null) {
+          const recurringEnd = new Date(`${recurringEndDate}T00:00:00Z`);
+          if (Number.isNaN(recurringEnd.getTime())) {
+            throw new Error("recurringEndDate must be 'YYYY-MM-DD'");
+          }
+          const firstIsoDay = isoWeekdayFromSwedish(days[0]);
+          const firstDate = dateFromISOWeek(year, week, firstIsoDay);
+          if (recurringEnd < firstDate) {
+            throw new Error('recurringEndDate cannot be earlier than start date');
+          }
+        }
+
+        const normalized: ActivityImportItem = {
+          name,
+          icon: icon == null ? undefined : String(icon),
+          startTime,
+          endTime,
+          participants,
+          location: location == null ? undefined : String(location),
+          notes: notes == null ? undefined : String(notes),
+          color: color == null ? undefined : String(color),
+          seriesId: baseSeriesId,
+          days,
+          week,
+          year,
+        };
+
+        if ((raw as { recurringEndDate?: unknown })?.recurringEndDate != null) {
+          normalized.recurringEndDate = String(
+            (raw as { recurringEndDate?: unknown })?.recurringEndDate,
+          );
+        }
+
+        ok.push(normalized);
+      };
+
+      if (rawDates.length > 0 || singleDate) {
+        const allDates = [...rawDates, ...(singleDate ? [String(singleDate)] : [])];
+        allDates.forEach((dateString) => {
+          const { week, year } = isoWeekYear(dateString);
+          const day = swedishDayFromDate(dateString);
+          pushWeekObject(week, year, [day]);
+        });
+        return;
+      }
+
+      let days = ensureArray((raw as { days?: unknown })?.days).map(normalizeSwedishDay);
+      if (!days.length) {
+        const singleDay = (raw as { day?: unknown })?.day;
+        if (singleDay) {
+          days = [normalizeSwedishDay(String(singleDay))];
+        }
+      }
+      if (!days.length) {
+        throw new Error("Provide 'days' or 'day' or 'date(s)'");
+      }
+
+      let week: number | undefined;
+      let year: number | undefined;
+
+      if (Number.isInteger((raw as { week?: unknown })?.week)) {
+        week = Number((raw as { week?: unknown })?.week);
+      }
+      if (Number.isInteger((raw as { year?: unknown })?.year)) {
+        year = Number((raw as { year?: unknown })?.year);
+      }
+
+      if (week == null) week = uiWeek;
+      if (year == null) year = uiYear;
+
+      if (!Number.isInteger(week) || !Number.isInteger(year)) {
+        throw new Error('week/year missing; cannot infer');
+      }
+
+      pushWeekObject(week as number, year as number, days);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Invalid activity';
+      errors.push({ index, message });
+    }
+  });
+
+  return { ok, errors };
+}

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -1,4 +1,6 @@
-import { SV_DAYS, type SwedishDay } from './dateSv';
+import type { SwedishDay } from '@/types/schedule';
+
+import { SV_DAYS } from './dateSv';
 
 const CANON: Record<string, SwedishDay> = Object.fromEntries(
   SV_DAYS.flatMap((day) => {

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -1,0 +1,24 @@
+import { SV_DAYS, type SwedishDay } from './dateSv';
+
+const CANON: Record<string, SwedishDay> = Object.fromEntries(
+  SV_DAYS.flatMap((day) => {
+    const lower = day.toLowerCase();
+    const short = day.slice(0, 3).toLowerCase();
+    const ascii = lower.normalize('NFD').replace(/\p{Diacritic}/gu, '');
+    const shortAscii = short.normalize('NFD').replace(/\p{Diacritic}/gu, '');
+    return [
+      [lower, day],
+      [short, day],
+      [ascii, day],
+      [shortAscii, day],
+    ];
+  }),
+);
+
+export function normalizeSwedishDay(value: unknown): SwedishDay {
+  if (typeof value !== 'string') throw new Error('day must be string');
+  const key = value.trim().toLowerCase();
+  const hit = CANON[key];
+  if (!hit) throw new Error(`Unknown day: ${value}`);
+  return hit;
+}

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,15 @@
+export function normalizeHHMM(raw: string): string {
+  if (typeof raw !== 'string') throw new Error('time must be string');
+  const m = raw.trim().match(/^(\d{1,2}):(\d{1,2})$/);
+  if (!m) throw new Error('Time must be HH:MM');
+  const h = parseInt(m[1], 10);
+  const min = parseInt(m[2], 10);
+  if (h < 0 || h > 23 || min < 0 || min > 59) throw new Error('Invalid time');
+  return `${h.toString().padStart(2, '0')}:${min.toString().padStart(2, '0')}`;
+}
+
+export function isStartBeforeEnd(startHHMM: string, endHHMM: string): boolean {
+  const [sh, sm] = startHHMM.split(':').map(Number);
+  const [eh, em] = endHHMM.split(':').map(Number);
+  return sh * 60 + sm < eh * 60 + em;
+}


### PR DESCRIPTION
## Summary
- add shared schedule import types and normalization helpers to convert AI output into week-based payloads
- expose the schedule AI parsing endpoint and extend the data modal with an AI assistant preview flow
- reuse the normalization pipeline for manual JSON imports while mapping participants to local members

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce905809c8832399c9fc41b2e19e3f