### PR TITLE
Align AI schedule import flow with backend service

### DIFF
--- a/src/components/familjeschema/components/AIAssistantTab.tsx
+++ b/src/components/familjeschema/components/AIAssistantTab.tsx
@@ -2,15 +2,11 @@ import { useState } from 'react';
 
 import { scheduleService } from '@/services/scheduleService';
 import type { ActivityImportItem } from '@/types/schedule';
-import { normalizeActivitiesForBackend } from '@/utils/normalizeActivities';
 
 interface AIAssistantTabProps {
   selectedWeek: number;
   selectedYear: number;
-  onPreview: (
-    ok: ActivityImportItem[],
-    errors: { index: number; message: string }[],
-  ) => void;
+  onPreview: (activities: ActivityImportItem[]) => void;
 }
 
 export function AIAssistantTab({ selectedWeek, selectedYear, onPreview }: AIAssistantTabProps) {
@@ -26,20 +22,16 @@ export function AIAssistantTab({ selectedWeek, selectedYear, onPreview }: AIAssi
     setError(null);
     try {
       const aiItems = await scheduleService.parseScheduleWithAI(text, selectedWeek, selectedYear);
-      const { ok, errors } = normalizeActivitiesForBackend(aiItems, selectedWeek, selectedYear);
-      onPreview(ok, errors);
-
-      if (!ok.length) {
-        setError(errors[0]?.message || 'AI gav inga giltiga aktiviteter.');
+      if (!aiItems.length) {
+        setError('AI gav inga giltiga aktiviteter.');
+        onPreview([]);
         return;
       }
 
-      if (errors.length) {
-        setError('Vissa rader kunde inte tolkas. Se detaljerna nedan.');
-      }
+      onPreview(aiItems);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Kunde inte tolka texten.');
-      onPreview([], []);
+      onPreview([]);
     } finally {
       setIsProcessing(false);
     }

--- a/src/components/familjeschema/components/DataModal.tsx
+++ b/src/components/familjeschema/components/DataModal.tsx
@@ -16,13 +16,8 @@ interface DataModalProps {
   onExportICS: () => void;
   selectedWeek: number;
   selectedYear: number;
-  onAIPreview: (
-    ok: ActivityImportItem[],
-    errors: { index: number; message: string }[],
-  ) => void;
+  onAIPreview: (activities: ActivityImportItem[]) => void;
   aiPreviewActivities: ActivityImportItem[];
-  aiPreviewErrors: { index: number; message: string }[];
-  aiParticipantWarnings: string[];
   onAIImport: () => void;
   aiImporting: boolean;
   aiImportError: string | null;
@@ -39,8 +34,6 @@ export const DataModal: React.FC<DataModalProps> = ({
   selectedYear,
   onAIPreview,
   aiPreviewActivities,
-  aiPreviewErrors,
-  aiParticipantWarnings,
   onAIImport,
   aiImporting,
   aiImportError,
@@ -68,44 +61,6 @@ export const DataModal: React.FC<DataModalProps> = ({
           selectedYear={selectedYear}
           onPreview={onAIPreview}
         />
-
-        {aiPreviewErrors.length > 0 && (
-          <div
-            style={{
-              backgroundColor: '#fff7ed',
-              border: '1px solid #fb923c',
-              borderRadius: '8px',
-              padding: '12px',
-            }}
-          >
-            <p className="form-label" style={{ marginBottom: '0.5rem' }}>
-              Några rader kunde inte importeras:
-            </p>
-            <ul className="text-sm" style={{ marginLeft: '1rem' }}>
-              {aiPreviewErrors.map((error, idx) => (
-                <li key={`${error.index}-${idx}`}>
-                  Rad {error.index + 1}: {error.message}
-                </li>
-              ))}
-            </ul>
-          </div>
-        )}
-
-        {aiParticipantWarnings.length > 0 && (
-          <div
-            style={{
-              backgroundColor: '#f0f9ff',
-              border: '1px solid #38bdf8',
-              borderRadius: '8px',
-              padding: '12px',
-            }}
-          >
-            <p className="form-label" style={{ marginBottom: '0.5rem' }}>
-              Okända deltagare hittades. De importeras som fritext:
-            </p>
-            <p className="text-sm">{aiParticipantWarnings.join(', ')}</p>
-          </div>
-        )}
 
         {aiImportError && (
           <pre
@@ -137,13 +92,13 @@ export const DataModal: React.FC<DataModalProps> = ({
               </thead>
               <tbody>
                 {aiPreviewActivities.map((activity, idx) => (
-                  <tr key={`${activity.name}-${idx}`}>
+                  <tr key={idx}>
                     <td style={{ padding: '6px', borderBottom: '1px solid #eee' }}>{activity.name}</td>
                     <td style={{ padding: '6px', borderBottom: '1px solid #eee' }}>
                       {activity.startTime} – {activity.endTime}
                     </td>
                     <td style={{ padding: '6px', borderBottom: '1px solid #eee' }}>
-                      {(activity.days || []).join(', ')}
+                      {activity.days.join(', ')}
                     </td>
                     <td style={{ padding: '6px', borderBottom: '1px solid #eee' }}>{activity.week}</td>
                     <td style={{ padding: '6px', borderBottom: '1px solid #eee' }}>{activity.year}</td>
@@ -155,6 +110,12 @@ export const DataModal: React.FC<DataModalProps> = ({
               </tbody>
             </table>
           </div>
+        )}
+
+        {!hasPreview && !aiImportError && (
+          <p className="text-sm text-gray-600">
+            Tolka en beskrivning för att förhandsgranska aktiviteter innan import.
+          </p>
         )}
       </div>
     );

--- a/src/types/schedule.ts
+++ b/src/types/schedule.ts
@@ -10,17 +10,11 @@ export type SwedishDay =
 export type ActivityImportItem = {
   name: string;
   icon?: string;
+  participants: string[];
   startTime: string;
   endTime: string;
-  participants: string[];
-  days?: SwedishDay[];
-  week?: number;
-  year?: number;
-  date?: string;
-  dates?: string[];
-  location?: string;
-  notes?: string;
-  color?: string;
+  days: SwedishDay[];
+  week: number;
+  year: number;
   seriesId?: string;
-  recurringEndDate?: string;
 };


### PR DESCRIPTION
## Summary
- align the ActivityImportItem type with the backend schema so AI imports work with IDs, days, week and year
- route AI parsing through the authenticated schedule API with client timeouts and localized Swedish error handling
- streamline the AI import UI to preview backend activities directly and drop client-side unknown participant handling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cefa2968a48323ae5388fff1310479