### PR TITLE
Include recurring flag when saving family schedule activities

### DIFF
--- a/src/components/familjeschema/FamilySchedule.tsx
+++ b/src/components/familjeschema/FamilySchedule.tsx
@@ -165,6 +165,7 @@ export function FamilySchedule() {
         endTime: activityFromForm.endTime,
         location: activityFromForm.location || undefined,
         notes: activityFromForm.notes || undefined,
+        recurring: activityFromForm.recurring,
         color: activityFromForm.color,
         week: selectedWeek,
         year: selectedYear,


### PR DESCRIPTION
## Summary
- add the missing recurring flag to the create/update payload for family schedule activities so the backend accepts recurring series

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d51fb2688c8323a10c386594ab8492