### PR TITLE
Include recurring flag when saving family schedule activities

### DIFF
--- a/src/components/familjeschema/FamilySchedule.tsx
+++ b/src/components/familjeschema/FamilySchedule.tsx
@@ -170,8 +170,11 @@ export function FamilySchedule() {
         year: selectedYear,
       };
 
-      if (activityFromForm.recurring && activityFromForm.recurringEndDate) {
-        payload.recurringEndDate = activityFromForm.recurringEndDate;
+      if (activityFromForm.recurring) {
+        payload.recurring = true;
+        if (activityFromForm.recurringEndDate) {
+          payload.recurringEndDate = activityFromForm.recurringEndDate;
+        }
       }
 
       if (editingActivity) {


### PR DESCRIPTION
## Summary
- stop sending `recurring: false` when saving activities so edits don't unintentionally clear recurrence
- still include the recurring end date when the user explicitly sets a series

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d51fb2688c8323a10c386594ab8492