### PR TITLE
Ensure recurring flag is sent when creating new family activities

### DIFF
--- a/src/components/familjeschema/FamilySchedule.tsx
+++ b/src/components/familjeschema/FamilySchedule.tsx
@@ -170,8 +170,13 @@ export function FamilySchedule() {
         year: selectedYear,
       };
 
-      if (activityFromForm.recurring && activityFromForm.recurringEndDate) {
-        payload.recurringEndDate = activityFromForm.recurringEndDate;
+      if (activityFromForm.recurring) {
+        payload.recurring = true;
+        if (activityFromForm.recurringEndDate) {
+          payload.recurringEndDate = activityFromForm.recurringEndDate;
+        }
+      } else if (!editingActivity) {
+        payload.recurring = false;
       }
 
       if (editingActivity) {


### PR DESCRIPTION
## Summary
- ensure new family schedule activities send an explicit `recurring` boolean so the backend accepts the payload
- keep recurrence data untouched while editing existing activities by only sending `recurring: false` for brand-new saves

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d51fb2688c8323a10c386594ab8492