### PR TITLE
Handle recurring end date without ts-expect-error

### DIFF
--- a/src/components/familjeschema/FamilySchedule.tsx
+++ b/src/components/familjeschema/FamilySchedule.tsx
@@ -170,8 +170,14 @@ export function FamilySchedule() {
         year: selectedYear,
       };
 
-      if (activityFromForm.recurring && activityFromForm.recurringEndDate) {
-        payload.recurringEndDate = activityFromForm.recurringEndDate;
+      if (activityFromForm.recurring) {
+        payload.recurring = true;
+        payload.recurringEndDate = activityFromForm.recurringEndDate || undefined;
+      } else {
+        if (!editingActivity) {
+          payload.recurring = false;
+        }
+        payload.recurringEndDate = undefined;
       }
 
       if (editingActivity) {


### PR DESCRIPTION
## Summary
- remove the unused `@ts-expect-error` and handle the recurring end date via defined assignments

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d51fb2688c8323a10c386594ab8492