### PR TITLE
Ensure recurring metadata persists

### DIFF
--- a/src/components/familjeschema/FamilySchedule.tsx
+++ b/src/components/familjeschema/FamilySchedule.tsx
@@ -172,9 +172,14 @@ export function FamilySchedule() {
       };
 
       if (activityFromForm.recurring) {
-        payload.recurring = true;
         if (activityFromForm.recurringEndDate) {
           payload.recurringEndDate = activityFromForm.recurringEndDate;
+        }
+      } else {
+        delete payload.recurringEndDate;
+
+        if (editingActivity?.seriesId && !applyToSeries) {
+          delete payload.recurring;
         }
       }
 


### PR DESCRIPTION
## Summary
- ensure the activity payload always includes the current recurring flag before additional adjustments
- prevent non-recurring submissions from sending a stray recurring end date and preserve series metadata during single-instance edits

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6609857488323b0c8ea76bb26c8db