### PR TITLE
Add quick JSON import area to family schedule sidebar

### DIFF
--- a/src/components/familjeschema/FamilySchedule.tsx
+++ b/src/components/familjeschema/FamilySchedule.tsx
@@ -518,6 +518,7 @@ export function FamilySchedule() {
         onExportPdf={handleExportPdf}
         onSystemPrint={handleSystemPrint}
         isPrinting={printing}
+        onQuickTextImport={handleTextImport}
       />
 
       <div className="schedule-main-content">

--- a/src/components/familjeschema/components/Sidebar.tsx
+++ b/src/components/familjeschema/components/Sidebar.tsx
@@ -12,7 +12,8 @@ import {
   GripVertical,
   Check,
   Loader2,
-  Printer
+  Printer,
+  Sparkles
 } from 'lucide-react';
 import type { FamilyMember } from '../types';
 import { Emoji } from '@/utils/Emoji';
@@ -39,6 +40,7 @@ interface SidebarProps {
   onExportPdf?: () => void;
   onSystemPrint?: () => void;
   isPrinting?: boolean;
+  onQuickTextImport: (jsonText: string) => void;
 }
 
 export const Sidebar: React.FC<SidebarProps> = ({
@@ -62,11 +64,13 @@ export const Sidebar: React.FC<SidebarProps> = ({
   onReorderMembers,
   onExportPdf,
   onSystemPrint,
-  isPrinting = false
+  isPrinting = false,
+  onQuickTextImport
 }) => {
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [draggedMemberId, setDraggedMemberId] = useState<string | null>(null);
   const [dragOverMemberId, setDragOverMemberId] = useState<string | null>(null);
+  const [quickImportText, setQuickImportText] = useState('');
   const showLabels = !isCollapsed;
   const canReorder = familyMembers.length > 1;
   const END_TARGET_ID = '__END__';
@@ -107,6 +111,29 @@ export const Sidebar: React.FC<SidebarProps> = ({
   const handleDragEnd = () => {
     setDraggedMemberId(null);
     setDragOverMemberId(null);
+  };
+
+  const handleQuickImport = () => {
+    const trimmed = quickImportText.trim();
+    if (!trimmed) return;
+    onQuickTextImport(trimmed);
+    setQuickImportText('');
+  };
+
+  const handleQuickImportKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
+      event.preventDefault();
+      handleQuickImport();
+    }
+  };
+
+  const handleGeminiLinkClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    const url = 'https://gemini.google.com/u/1/gem/52527d352450';
+    const newWindow = window.open(url, 'familyscheduleGemini', 'width=720,height=640,noopener');
+    if (newWindow) {
+      newWindow.focus();
+      event.preventDefault();
+    }
   };
 
   const membersClassName = [
@@ -321,6 +348,42 @@ export const Sidebar: React.FC<SidebarProps> = ({
             <Settings size={18} />
             {!isCollapsed && <span>Inställningar</span>}
           </button>
+          {!isCollapsed && (
+            <div className="sidebar-quick-import" role="region" aria-label="Snabbimport av JSON">
+              <label htmlFor="sidebar-quick-import" className="sr-only">
+                Snabbimport av JSON-data
+              </label>
+              <textarea
+                id="sidebar-quick-import"
+                className="sidebar-quick-import-input"
+                rows={3}
+                placeholder="Klistra in JSON och tryck på import"
+                value={quickImportText}
+                onChange={(event) => setQuickImportText(event.target.value)}
+                onKeyDown={handleQuickImportKeyDown}
+              />
+              <div className="sidebar-quick-import-actions">
+                <button
+                  type="button"
+                  className="btn-compact btn-primary"
+                  onClick={handleQuickImport}
+                  disabled={!quickImportText.trim()}
+                >
+                  Importera JSON
+                </button>
+              </div>
+              <a
+                href="https://gemini.google.com/u/1/gem/52527d352450"
+                className="sidebar-quick-import-link"
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={handleGeminiLinkClick}
+                aria-label="Öppna Gemini-guiden i ett nytt fönster"
+              >
+                <Sparkles size={16} aria-hidden="true" />
+              </a>
+            </div>
+          )}
         </div>
       </aside>
 

--- a/src/components/familjeschema/styles/neobrutalism.css
+++ b/src/components/familjeschema/styles/neobrutalism.css
@@ -1773,6 +1773,65 @@ button.member-badge:hover {
   background: var(--neo-bg);
 }
 
+.sidebar-quick-import {
+  margin-top: 4px;
+  padding: 10px;
+  border: 2px solid var(--neo-black);
+  border-radius: 12px;
+  background: var(--neo-white);
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.sidebar-quick-import-input {
+  width: 100%;
+  min-height: 70px;
+  resize: vertical;
+  padding: 8px 10px;
+  border: 2px dashed var(--neo-black);
+  border-radius: 10px;
+  font-size: 0.85rem;
+  line-height: 1.4;
+  font-family: 'Space Grotesk', monospace;
+  background: var(--neo-bg);
+  transition: box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.sidebar-quick-import-input:focus {
+  outline: none;
+  border-style: solid;
+  box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.1);
+}
+
+.sidebar-quick-import-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.sidebar-quick-import-link {
+  align-self: flex-end;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 2px solid transparent;
+  color: var(--neo-black);
+  opacity: 0.65;
+  transition: opacity 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+}
+
+.sidebar-quick-import-link:hover,
+.sidebar-quick-import-link:focus {
+  opacity: 1;
+  transform: translateY(-1px);
+  border-color: var(--neo-black);
+  outline: none;
+}
+
 /* Main Content Area */
 
 .schedule-main-content {


### PR DESCRIPTION
## Summary
- add a compact JSON import textarea under the family schedule settings action
- wire the quick import control to the existing JSON import handler and style it for the neobrutalist sidebar
- surface a subtle Gemini helper link that opens in a small window when possible

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d669b707cc8323a29b6deb834dfbc4