### PR TITLE
Remove PDF export option from family schedule sidebar

### DIFF
--- a/src/components/familjeschema/components/Sidebar.tsx
+++ b/src/components/familjeschema/components/Sidebar.tsx
@@ -37,9 +37,7 @@ interface SidebarProps {
   onStartReorder: () => void;
   onSubmitReorder: () => void;
   onReorderMembers: (sourceId: string, targetId: string | null) => void;
-  onExportPdf?: () => void;
   onSystemPrint?: () => void;
-  isPrinting?: boolean;
   onQuickTextImport: (jsonText: string) => void;
 }
 
@@ -62,9 +60,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
   onStartReorder,
   onSubmitReorder,
   onReorderMembers,
-  onExportPdf,
   onSystemPrint,
-  isPrinting = false,
   onQuickTextImport
 }) => {
   const [isCollapsed, setIsCollapsed] = useState(false);
@@ -320,22 +316,9 @@ export const Sidebar: React.FC<SidebarProps> = ({
           <button
             type="button"
             className="btn-compact"
-            onClick={() => onExportPdf?.()}
-            title="Spara som PDF"
-            aria-label="Spara som PDF"
-            disabled={isPrinting}
-            aria-busy={isPrinting}
-          >
-            <Printer size={18} />
-            {!isCollapsed && <span>Spara som PDF</span>}
-          </button>
-          <button
-            type="button"
-            className="btn-compact"
             onClick={() => onSystemPrint?.()}
             title="Skriv ut"
             aria-label="Skriv ut"
-            disabled={isPrinting}
           >
             <Printer size={18} />
             {!isCollapsed && <span>Skriv ut</span>}


### PR DESCRIPTION
## Summary
- remove the Save as PDF action and related printing state from the family schedule view
- keep the print button available while simplifying the sidebar props

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d66ea51a808323a24985142b775e68