### PR TITLE
Fix family schedule print scaling

### DIFF
--- a/src/components/familjeschema/styles/print.css
+++ b/src/components/familjeschema/styles/print.css
@@ -1,5 +1,10 @@
 /* Print-specific styles for the familjeschema feature */
 
+@page {
+  size: landscape;
+  margin: 10mm;
+}
+
 /* System print (window.print) */
 @media print {
   body * {
@@ -33,6 +38,8 @@
     left: 0 !important;
     top: 0 !important;
     width: 100% !important;
+    max-height: 100% !important;
+    overflow: visible !important;
   }
 }
 
@@ -54,4 +61,10 @@
   -webkit-print-color-adjust: exact;
   print-color-adjust: exact;
 
+}
+
+.printable-schedule-scope.print-scaling {
+  transform-origin: top left;
+  break-inside: avoid;
+  page-break-inside: avoid;
 }


### PR DESCRIPTION
## Summary
- scale the printable family schedule so the full grid fits on a single landscape page
- ensure print styles support landscape output without clipping or losing colors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7ae765e5c8323a42f3dc7fd0f3735