### PR TITLE
Set white background for family schedule page

### DIFF
--- a/src/app/(full-width)/features/familjeschema/page.tsx
+++ b/src/app/(full-width)/features/familjeschema/page.tsx
@@ -1,6 +1,8 @@
 // src/app/(full-width)/features/familjeschema/page.tsx
 'use client';
 
+import { useEffect } from 'react';
+
 import { FamilySchedule } from '@/components/familjeschema/FamilySchedule';
 import ProtectedRoute from '@/components/ProtectedRoute';
 
@@ -9,6 +11,14 @@ import '@/components/familjeschema/styles/neobrutalism.css';
 import '@/components/familjeschema/styles/print.css';
 
 export default function FamilySchedulePage() {
+  useEffect(() => {
+    document.body.classList.add('family-schedule-body');
+
+    return () => {
+      document.body.classList.remove('family-schedule-body');
+    };
+  }, []);
+
   return (
     <ProtectedRoute>
       <div className="family-schedule-container">

--- a/src/components/familjeschema/styles/neobrutalism.css
+++ b/src/components/familjeschema/styles/neobrutalism.css
@@ -32,6 +32,11 @@ body {
   line-height: 1.5;
 }
 
+body.family-schedule-body {
+  background: var(--neo-white);
+  --neo-bg: var(--neo-white);
+}
+
 .app-container {
   min-height: 100vh;
   padding: 20px;


### PR DESCRIPTION
## Summary
- add a body-level class when visiting the family schedule feature to override the theme background color
- update the neobrutalism stylesheet so the page background variables resolve to white while the feature is active

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de41e6508083239803d54bd16b8a5f