### PR TITLE
Remove tinted schedule day backgrounds to fix print artifacts

### DIFF
--- a/src/components/familjeschema/styles/neobrutalism.css
+++ b/src/components/familjeschema/styles/neobrutalism.css
@@ -888,23 +888,11 @@ h1 {
   font-size: 0.85rem;
 }
 
-/* Subtle background tint for busy columns */
-.day-column.day-intensity-low .day-content {
-  background: linear-gradient(180deg, 
-    transparent 0%, 
-    rgba(255, 223, 61, 0.05) 100%);
-}
-
-.day-column.day-intensity-medium .day-content {
-  background: linear-gradient(180deg, 
-    transparent 0%, 
-    rgba(255, 159, 69, 0.08) 100%);
-}
-
+/* Remove tinted backgrounds to avoid print artifacts */
+.day-column.day-intensity-low .day-content,
+.day-column.day-intensity-medium .day-content,
 .day-column.day-intensity-high .day-content {
-  background: linear-gradient(180deg, 
-    transparent 0%, 
-    rgba(255, 107, 107, 0.1) 100%);
+  background: var(--neo-white);
 }
 
 /* Improved activity separation in high-density scenarios */


### PR DESCRIPTION
## Summary
- remove the gradient backgrounds applied to day-intensity columns in the family schedule styles
- ensure printed schedules no longer display yellow-tinted columns caused by the gradients

## Testing
- npm run dev (terminated after manual verification; fails to fetch remote telemetry data in CI environment)


------
https://chatgpt.com/codex/tasks/task_e_68de48995770832391561faa6e53261a