### PR TITLE
Clarify medium family schedule time hiding

### DIFF
--- a/src/components/familjeschema/components/ActivityBlock.tsx
+++ b/src/components/familjeschema/components/ActivityBlock.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useMemo } from 'react';
 import type { Activity, FamilyMember } from '../types';
 import { HoverCard } from './HoverCard';
 import { Emoji } from '@/utils/Emoji';
@@ -29,6 +29,26 @@ export const ActivityBlock: React.FC<ActivityBlockProps> = ({
   const [isCardVisible, setCardVisible] = useState(false);
   const [positionClasses, setPositionClasses] = useState('');
   const wrapperRef = useRef<HTMLDivElement>(null);
+
+  const durationInMinutes = useMemo(() => {
+    const parseTime = (time: string) => {
+      const [hours, minutes] = time.split(':').map(Number);
+      return hours * 60 + minutes;
+    };
+
+    const start = parseTime(activity.startTime);
+    const end = parseTime(activity.endTime);
+
+    if (Number.isNaN(start) || Number.isNaN(end)) {
+      return 0;
+    }
+
+    return Math.max(end - start, 0);
+  }, [activity.startTime, activity.endTime]);
+
+  const isLongDuration = durationInMinutes >= 120;
+  const isMediumDuration = durationInMinutes >= 120 && durationInMinutes < 150;
+  const shouldHideTime = isMediumDuration;
 
   const handleMouseEnter = () => {
     if (!wrapperRef.current) return;
@@ -90,6 +110,9 @@ export const ActivityBlock: React.FC<ActivityBlockProps> = ({
   if (height < 45) {
     activityBlockClasses.push('activity-block-extra-compact');
   }
+  if (isLongDuration) {
+    activityBlockClasses.push('activity-block-long');
+  }
 
   return (
     <div
@@ -113,14 +136,25 @@ export const ActivityBlock: React.FC<ActivityBlockProps> = ({
         aria-label={`${activity.name} från ${activity.startTime} till ${activity.endTime}`}
         onKeyDown={handleKeyDown}
       >
-        <div className="activity-name">
-          <Emoji emoji={activity.icon} />
-          {activity.name}
+        <div className={`activity-name${isLongDuration ? ' activity-name-long' : ''}`}>
+          {isLongDuration ? (
+            <>
+              <Emoji emoji={activity.icon} className="activity-name-icon" />
+              <span className="activity-name-text">{activity.name}</span>
+            </>
+          ) : (
+            <>
+              <Emoji emoji={activity.icon} />
+              {activity.name}
+            </>
+          )}
         </div>
-        <div className="activity-time">
-          {activity.startTime} – {activity.endTime}
-        </div>
-        <div className="activity-participants">
+        {!shouldHideTime && (
+          <div className="activity-time">
+            {activity.startTime} – {activity.endTime}
+          </div>
+        )}
+        <div className={`activity-participants${isLongDuration ? ' activity-participants-long' : ''}`}>
           {participants.map(p => (
             <span key={p.id} aria-label={p.name}>
               <Emoji emoji={p.icon} />

--- a/src/components/familjeschema/styles/neobrutalism.css
+++ b/src/components/familjeschema/styles/neobrutalism.css
@@ -403,6 +403,11 @@ h1 {
   gap: 4px;
 }
 
+.activity-block.activity-block-long {
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
 .activity-block:hover {
   transform: translate(-2px, -2px);
   box-shadow: 4px 4px 0 var(--neo-black);
@@ -418,15 +423,45 @@ h1 {
   /* text-overflow: ellipsis; <-- REMOVED */
 }
 
+.activity-name.activity-name-long {
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 10px;
+}
+
+.activity-name.activity-name-long .activity-name-icon {
+  display: flex;
+  justify-content: center;
+  font-size: 1.6rem;
+}
+
+.activity-name.activity-name-long .activity-name-text {
+  text-align: center;
+}
+
 .activity-time {
   font-size: .75rem;
   opacity: .9;
+}
+
+.activity-block.activity-block-long .activity-time {
+  text-align: center;
 }
 
 .activity-participants {
   display: flex;
   gap: 4px;
   flex-wrap: wrap;
+}
+
+.activity-participants.activity-participants-long {
+  justify-content: center;
+  margin-top: auto;
+}
+
+.activity-participants.activity-participants-long span {
+  display: flex;
 }
 
 /* Styles for smaller activity blocks */


### PR DESCRIPTION
## Summary
- define a dedicated medium-duration flag for family schedule activities lasting at least two but less than two and a half hours
- hide the time label only for those medium-length blocks without adding unused styling classes

## Testing
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68df8d87c5388323a90a281177952df1