### PR TITLE
Fix ActivityBlock layout closing structure

### DIFF
--- a/src/components/familjeschema/components/ActivityBlock.tsx
+++ b/src/components/familjeschema/components/ActivityBlock.tsx
@@ -154,10 +154,6 @@ export const ActivityBlock: React.FC<ActivityBlockProps> = ({
             {activity.startTime} – {activity.endTime}
           </div>
         )}
-        </div>
-        <div className="activity-time">
-          {activity.startTime} – {activity.endTime}
-        </div>
         <div className={`activity-participants${isLongDuration ? ' activity-participants-long' : ''}`}>
           {participants.map(p => (
             <span key={p.id} aria-label={p.name}>
@@ -166,9 +162,9 @@ export const ActivityBlock: React.FC<ActivityBlockProps> = ({
           ))}
         </div>
       </div>
-      <HoverCard 
-        activity={activity} 
-        familyMembers={familyMembers} 
+      <HoverCard
+        activity={activity}
+        familyMembers={familyMembers}
         positionClasses={positionClasses}
         isVisible={isCardVisible}
       />


### PR DESCRIPTION
## Summary
- remove the stray wrapper closing tag in the ActivityBlock component that broke the HoverCard props list
- keep the activity time markup inside the conditional block instead of duplicating it

## Testing
- pnpm run build *(fails: missing dependencies emoji-picker-react and several @radix-ui packages)*

------
https://chatgpt.com/codex/tasks/task_e_68df9bc742d48323b0e89af6fca25fee