### PR TITLE
Revert FamilySchedule UI to commit 82ca560

### DIFF
--- a/src/components/familjeschema/FamilySchedule.tsx
+++ b/src/components/familjeschema/FamilySchedule.tsx
@@ -39,7 +39,6 @@ export function FamilySchedule() {
   const settingsModalRef = useRef<HTMLDivElement>(null);
   const originalMemberOrderRef = useRef<FamilyMember[]>([]);
   const scheduleRef = useRef<HTMLDivElement>(null);
-  const hasLoadedInitialData = useRef(false);
 
   const [activities, setActivities] = useState<Activity[]>([]);
   const [familyMembers, setFamilyMembers] = useState<FamilyMember[]>([]);
@@ -78,30 +77,8 @@ export function FamilySchedule() {
   };
 
   useEffect(() => {
-    if (hasLoadedInitialData.current) return;
-    hasLoadedInitialData.current = true;
-
-    const loadInitialData = async () => {
-      try {
-        setLoading(true);
-        setError(null);
-        const [activitiesData, membersData, settingsData] = await Promise.all([
-          scheduleService.getActivities(selectedYear, selectedWeek),
-          scheduleService.getFamilyMembers(),
-          scheduleService.getSettings()
-        ]);
-        setActivities(activitiesData);
-        setFamilyMembers(membersData);
-        if (settingsData) setSettings(normalizeSettings(settingsData));
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Kunde inte hämta schemadata.');
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    void loadInitialData();
-  }, [selectedWeek, selectedYear]);
+    fetchData();
+  }, []);
 
   useEffect(() => {
     if (!modalOpen) return;
@@ -130,24 +107,6 @@ export function FamilySchedule() {
 
   const participantIdSet = useMemo(() => new Set(familyMembers.map(member => member.id)), [familyMembers]);
 
-  const uniqueParticipantCount = useMemo(() => {
-    const unique = new Set<string>();
-    activities.forEach(activity => {
-      activity.participants.forEach(participant => {
-        if (participant) unique.add(participant);
-      });
-    });
-    return unique.size;
-  }, [activities]);
-
-  const busyDayCount = useMemo(() => {
-    const unique = new Set<string>();
-    activities.forEach(activity => {
-      if (activity.day) unique.add(activity.day);
-    });
-    return unique.size;
-  }, [activities]);
-
   const mapParticipantsForImport = (items: ActivityImportItem[]): ActivityImportItem[] =>
     items.map(item => {
       const mappedParticipants = item.participants.map(participant => {
@@ -171,6 +130,25 @@ export function FamilySchedule() {
     setAiPreviewActivities([]);
     setAiImportError(null);
     setAiImporting(false);
+  };
+
+  const fetchData = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const [activitiesData, membersData, settingsData] = await Promise.all([
+        scheduleService.getActivities(selectedYear, selectedWeek),
+        scheduleService.getFamilyMembers(),
+        scheduleService.getSettings()
+      ]);
+      setActivities(activitiesData);
+      setFamilyMembers(membersData);
+      if (settingsData) setSettings(normalizeSettings(settingsData));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Kunde inte hämta schemadata.');
+    } finally {
+      setLoading(false);
+    }
   };
 
   useFocusTrap(modalRef, modalOpen);
@@ -460,13 +438,6 @@ export function FamilySchedule() {
   const days = settings.showWeekends ? ALL_DAYS : WEEKDAYS_FULL;
   const timeSlots = generateTimeSlots(settings.dayStart, settings.dayEnd);
   const weekDates = getWeekDateRange(selectedWeek, selectedYear, days.length);
-  const formatDate = (date: Date) => date.toLocaleDateString('sv-SE', {
-    month: 'short',
-    day: 'numeric'
-  });
-  const weekRangeLabel = weekDates.length
-    ? `${formatDate(weekDates[0])} – ${formatDate(weekDates[weekDates.length - 1])}`
-    : '';
   const printSheetClass = settings.printPageSize === 'a3' ? 'print-sheet-a3' : 'print-sheet-a4';
   const navigateWeek = (direction: number) => {
     const monday = getWeekDateRange(selectedWeek, selectedYear, 1)[0];
@@ -628,34 +599,14 @@ export function FamilySchedule() {
     }, 1000);
   };
 
-  return (
-    <div className="schedule-app-wrapper">
-      <div className="schedule-hero-panel">
-        <div className="schedule-hero-copy">
-          <span className="schedule-hero-kicker">Familjeschema</span>
-          <h1>Planera veckan med stil</h1>
-          <p>Snabb överblick över er vecka och alla aktiviteter.</p>
-        </div>
-        <div className="schedule-hero-meta">
-          <div className="schedule-hero-card">
-            <span className="label">Aktiviteter</span>
-            <strong>{activities.length}</strong>
-          </div>
-          <div className="schedule-hero-card">
-            <span className="label">Deltagare</span>
-            <strong>{uniqueParticipantCount}</strong>
-          </div>
-          <div className="schedule-hero-card">
-            <span className="label">Aktiva dagar</span>
-            <strong>{busyDayCount}</strong>
-          </div>
-        </div>
-      </div>
+  if (loading) return <div className="text-center p-10 font-monument">Laddar schema...</div>;
+  if (error) return <div className="text-center p-10 font-monument text-red-600">Fel: {error}</div>;
 
-      <div className="schedule-app-container schedule-app-surface">
-        <Sidebar
-          familyMembers={familyMembers}
-          selectedWeek={selectedWeek}
+  return (
+    <div className="schedule-app-container">
+      <Sidebar
+        familyMembers={familyMembers}
+        selectedWeek={selectedWeek}
         selectedYear={selectedYear}
         isCurrentWeek={isCurrentWeek}
         viewMode={viewMode}
@@ -672,95 +623,46 @@ export function FamilySchedule() {
         onStartReorder={handleStartMemberReorder}
         onSubmitReorder={handleSubmitMemberReorder}
         onReorderMembers={handleReorderMembers}
-          onSystemPrint={handleSystemPrint}
-          onQuickTextImport={handleTextImport}
-        />
-        <div className="schedule-main-card">
-          <header className="schedule-main-header">
-            <div className="schedule-header-titles">
-              <span className="schedule-header-kicker">Vecka {selectedWeek}</span>
-              <h2>{weekRangeLabel}</h2>
-              <p>År {selectedYear}</p>
-            </div>
-            <div className="schedule-header-meta">
-              <span className="schedule-meta-chip">{activities.length} aktiviteter</span>
-              <span className="schedule-meta-chip">{uniqueParticipantCount || 0} deltagare</span>
-              <span className="schedule-meta-chip">{busyDayCount || 0} dagar med aktiviteter</span>
-            </div>
-            <div className="schedule-header-actions" role="group" aria-label="Byt vy">
-              <button
-                type="button"
-                className={`schedule-view-btn ${viewMode === 'grid' ? 'active' : ''}`}
-                onClick={() => setViewMode('grid')}
-              >
-                Rutnät
-              </button>
-              <button
-                type="button"
-                className={`schedule-view-btn ${viewMode === 'layer' ? 'active' : ''}`}
-                onClick={() => setViewMode('layer')}
-              >
-                Lager
-              </button>
-            </div>
-          </header>
+        onSystemPrint={handleSystemPrint}
+        onQuickTextImport={handleTextImport}
+      />
 
-          <div className="schedule-main-content">
-            {/* Notifications */}
-            {!isCurrentWeek && !error && (
-              <div className="compact-notice" role="alert">
-                <AlertCircle size={18}/>
-                <span>Du tittar på {isWeekInPast(weekDates) ? 'en tidigare' : isWeekInFuture(weekDates) ? 'en kommande' : 'en annan'} vecka</span>
-              </div>
-            )}
-            {showConflict && !error && (
-              <div className="compact-notice conflict" role="alert">
-                <AlertCircle size={18}/>
-                <span>Tidskonflikt! En deltagare är redan upptagen.</span>
-              </div>
-            )}
-
-            {/* Main Schedule View */}
-            {error ? (
-              <div className="schedule-empty-state error" role="alert">
-                <AlertCircle size={28} />
-                <div>
-                  <h3>Kunde inte hämta schemat just nu</h3>
-                  <p>{error}</p>
-                </div>
-              </div>
-            ) : loading && !activities.length ? (
-              <div className="schedule-empty-state" role="status">
-                <div className="loader" aria-hidden="true" />
-                <div>
-                  <h3>Laddar veckans aktiviteter</h3>
-                  <p>Häng kvar, vi hämtar informationen.</p>
-                </div>
-              </div>
-            ) : (
-              <div
-                className={`schedule-view-container printable-schedule-scope ${printSheetClass}`}
-                ref={scheduleRef}
-              >
-                {viewMode === 'grid' ? (
-                  <ScheduleGrid
-                    days={days} weekDates={weekDates} timeSlots={timeSlots}
-                    activities={activities} familyMembers={familyMembers}
-                    settings={settings} selectedWeek={selectedWeek}
-                    selectedYear={selectedYear} onActivityClick={handleActivityClick}
-                  />
-                ) : (
-                  <LayerView
-                    days={days} weekDates={weekDates} timeSlots={timeSlots}
-                    activities={activities} familyMembers={familyMembers}
-                    settings={settings} selectedWeek={selectedWeek}
-                    selectedYear={selectedYear} onActivityClick={handleActivityClick}
-                    highlightedMemberId={highlightedMemberId}
-                  />
-                )}
-              </div>
-            )}
+      <div className="schedule-main-content">
+        {/* Notifications */}
+        {!isCurrentWeek && (
+          <div className="compact-notice" role="alert">
+            <AlertCircle size={18}/>
+            <span>Du tittar på {isWeekInPast(weekDates) ? 'en tidigare' : isWeekInFuture(weekDates) ? 'en kommande' : 'en annan'} vecka</span>
           </div>
+        )}
+        {showConflict && (
+          <div className="compact-notice conflict" role="alert">
+            <AlertCircle size={18}/> 
+            <span>Tidskonflikt! En deltagare är redan upptagen.</span>
+          </div>
+        )}
+
+        {/* Main Schedule View */}
+        <div
+          className={`schedule-view-container printable-schedule-scope ${printSheetClass}`}
+          ref={scheduleRef}
+        >
+          {viewMode === 'grid' ? (
+            <ScheduleGrid
+              days={days} weekDates={weekDates} timeSlots={timeSlots}
+              activities={activities} familyMembers={familyMembers}
+              settings={settings} selectedWeek={selectedWeek}
+              selectedYear={selectedYear} onActivityClick={handleActivityClick}
+            />
+          ) : (
+            <LayerView
+              days={days} weekDates={weekDates} timeSlots={timeSlots}
+              activities={activities} familyMembers={familyMembers}
+              settings={settings} selectedWeek={selectedWeek}
+              selectedYear={selectedYear} onActivityClick={handleActivityClick}
+              highlightedMemberId={highlightedMemberId}
+            />
+          )}
         </div>
       </div>
 

--- a/src/components/familjeschema/styles/neobrutalism.css
+++ b/src/components/familjeschema/styles/neobrutalism.css
@@ -1429,138 +1429,27 @@ button.member-badge:hover {
    ============================================ */
 
 /* Main App Container with Sidebar */
-.schedule-app-wrapper {
-  min-height: 100vh;
-  background: var(--neo-bg);
-  padding: 30px clamp(16px, 3vw, 48px) 40px;
-  display: flex;
-  flex-direction: column;
-  gap: 24px;
-}
-
-.schedule-hero-panel {
-  position: relative;
-  display: flex;
-  justify-content: space-between;
-  align-items: stretch;
-  gap: clamp(16px, 4vw, 40px);
-  padding: clamp(20px, 4vw, 36px);
-  background: var(--neo-yellow);
-  border: 3px solid var(--neo-black);
-  border-radius: 26px;
-  box-shadow: 6px 6px 0 var(--neo-black);
-  overflow: hidden;
-}
-
-.schedule-hero-panel::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: repeating-linear-gradient(
-    -45deg,
-    rgba(255, 255, 255, 0.18),
-    rgba(255, 255, 255, 0.18) 12px,
-    transparent 12px,
-    transparent 26px
-  );
-  mix-blend-mode: soft-light;
-  pointer-events: none;
-}
-
-.schedule-hero-copy {
-  position: relative;
-  z-index: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  max-width: 420px;
-}
-
-.schedule-hero-copy h1 {
-  font-size: clamp(1.6rem, 3vw, 2.4rem);
-  line-height: 1.1;
-  margin: 0;
-}
-
-.schedule-hero-copy p {
-  margin: 0;
-  font-size: 0.95rem;
-  max-width: 38ch;
-}
-
-.schedule-hero-kicker {
-  font-size: 0.85rem;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  font-weight: 700;
-}
-
-.schedule-hero-meta {
-  position: relative;
-  z-index: 1;
-  display: grid;
-  grid-template-columns: repeat(3, minmax(90px, 140px));
-  gap: 14px;
-  align-items: stretch;
-}
-
-.schedule-hero-card {
-  background: var(--neo-white);
-  border: 3px solid var(--neo-black);
-  border-radius: 18px;
-  padding: 16px 18px;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  box-shadow: 4px 4px 0 var(--neo-black);
-  text-align: left;
-}
-
-.schedule-hero-card .label {
-  font-size: 0.75rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.schedule-hero-card strong {
-  font-size: clamp(1.2rem, 2.8vw, 1.8rem);
-  font-weight: 800;
-}
-
 .schedule-app-container {
   display: flex;
-  min-height: 0;
-  background: transparent;
+  min-height: 100vh;
+  background: var(--neo-bg);
   position: relative;
-  gap: clamp(16px, 3vw, 28px);
-}
-
-.schedule-app-surface {
-  border: 3px solid var(--neo-black);
-  border-radius: 28px;
-  background: var(--neo-white);
-  padding: clamp(16px, 3vw, 28px);
-  box-shadow: 8px 8px 0 var(--neo-black);
 }
 
 /* Sidebar Styles */
 .sidebar {
   width: 280px;
   background: var(--neo-white);
-  border: 3px solid var(--neo-black);
-  border-radius: 24px;
+  border-right: 3px solid var(--neo-black);
   display: flex;
   flex-direction: column;
   position: sticky;
-  top: clamp(20px, 5vh, 50px);
-  max-height: calc(100vh - clamp(40px, 10vh, 100px));
+  top: 0;
+  height: 100vh;
   overflow-y: auto;
   overflow-x: hidden;
   transition: width 0.3s ease;
   z-index: 30;
-  box-shadow: 6px 6px 0 var(--neo-black);
-  flex-shrink: 0;
 }
 
 .sidebar.collapsed {
@@ -1973,158 +1862,12 @@ button.member-badge:hover {
 
 /* Main Content Area */
 
-.schedule-main-card {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  background: var(--neo-white);
-  border: 3px solid var(--neo-black);
-  border-radius: 24px;
-  box-shadow: 6px 6px 0 var(--neo-black);
-  overflow: hidden;
-}
-
-.schedule-main-header {
-  display: grid;
-  grid-template-columns: minmax(200px, 1fr) auto;
-  grid-template-areas:
-    'titles actions'
-    'meta actions';
-  gap: 18px;
-  padding: clamp(20px, 3vw, 32px);
-  border-bottom: 3px solid var(--neo-black);
-  background: var(--neo-bg);
-}
-
-.schedule-header-titles {
-  grid-area: titles;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.schedule-header-kicker {
-  font-size: 0.8rem;
-  font-weight: 700;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-}
-
-.schedule-main-header h2 {
-  font-size: clamp(1.4rem, 2.6vw, 2rem);
-  margin: 0;
-}
-
-.schedule-main-header p {
-  margin: 0;
-  font-size: 0.95rem;
-}
-
-.schedule-header-meta {
-  grid-area: meta;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  align-items: center;
-}
-
-.schedule-meta-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 8px 14px;
-  border: 3px solid var(--neo-black);
-  border-radius: 999px;
-  background: var(--neo-white);
-  font-size: 0.8rem;
-  font-weight: 700;
-  box-shadow: 3px 3px 0 var(--neo-black);
-}
-
-.schedule-header-actions {
-  grid-area: actions;
-  display: inline-flex;
-  align-items: center;
-  gap: 12px;
-  align-self: center;
-}
-
-.schedule-view-btn {
-  border: 3px solid var(--neo-black);
-  border-radius: 16px;
-  background: var(--neo-white);
-  font-weight: 700;
-  padding: 10px 18px;
-  box-shadow: 3px 3px 0 var(--neo-black);
-  transition: transform 0.1s ease, box-shadow 0.1s ease;
-}
-
-.schedule-view-btn:hover,
-.schedule-view-btn:focus {
-  transform: translate(-1px, -1px);
-  box-shadow: 4px 4px 0 var(--neo-black);
-  outline: none;
-}
-
-.schedule-view-btn.active {
-  background: var(--neo-purple);
-  color: var(--neo-white);
-}
-
 .schedule-main-content {
   flex: 1;
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  padding: clamp(18px, 3vw, 30px);
-  gap: 18px;
-  background: var(--neo-white);
-}
-
-.schedule-empty-state {
-  display: flex;
-  gap: 16px;
-  align-items: center;
-  padding: 24px;
-  border: 3px solid var(--neo-black);
-  border-radius: 18px;
-  background: var(--neo-bg);
-  box-shadow: 4px 4px 0 var(--neo-black);
-}
-
-.schedule-empty-state h3 {
-  margin: 0 0 4px;
-  font-size: 1.1rem;
-}
-
-.schedule-empty-state p {
-  margin: 0;
-  font-size: 0.95rem;
-}
-
-.schedule-empty-state.error {
-  background: var(--neo-pink);
-  color: var(--neo-white);
-}
-
-.schedule-empty-state.error h3,
-.schedule-empty-state.error p {
-  color: inherit;
-}
-
-.loader {
-  width: 30px;
-  height: 30px;
-  border-radius: 50%;
-  border: 4px solid var(--neo-black);
-  border-top-color: transparent;
-  animation: spin 1s linear infinite;
-}
-
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
+  padding: 0 20px 20px;
 }
 
 /* Compact Notices */
@@ -2132,7 +1875,7 @@ button.member-badge:hover {
   background: var(--neo-yellow);
   border: 2px solid var(--neo-black);
   padding: 10px 15px;
-  margin: 0;
+  margin-bottom: 15px;
   display: flex;
   align-items: center;
   gap: 10px;
@@ -2152,15 +1895,7 @@ button.member-badge:hover {
   overflow: auto;
   background: var(--neo-white);
   border: 3px solid var(--neo-black);
-  border-radius: 18px;
-  box-shadow: 4px 4px 0 var(--neo-black);
-  background-image: repeating-linear-gradient(
-    -45deg,
-    rgba(0, 0, 0, 0.04),
-    rgba(0, 0, 0, 0.04) 6px,
-    transparent 6px,
-    transparent 12px
-  );
+  box-shadow: var(--shadow-xl);
 }
 
 /* Mobile Menu Button (Hidden on Desktop) */
@@ -2183,42 +1918,10 @@ button.member-badge:hover {
 
 /* Responsive Design */
 @media (max-width: 1200px) {
-  .schedule-hero-panel {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  .schedule-hero-meta {
-    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-    width: 100%;
-  }
-
-  .schedule-app-container {
-    flex-direction: column;
-  }
-
   .sidebar {
-    position: relative;
-    top: 0;
-    max-height: none;
-    width: 100%;
+    width: 240px;
   }
-
-  .schedule-main-card {
-    min-height: 500px;
-  }
-
-  .schedule-main-header {
-    grid-template-columns: 1fr;
-    grid-template-areas:
-      'titles'
-      'meta'
-      'actions';
-  }
-
-  .schedule-header-actions {
-    justify-content: flex-start;
-  }
+  
 }
 
 @media (max-width: 992px) {
@@ -2229,31 +1932,24 @@ button.member-badge:hover {
     transform: translateX(-100%);
     width: 280px;
     box-shadow: var(--shadow-xl);
-    max-height: 100vh;
   }
-
+  
   .sidebar:not(.collapsed) {
     transform: translateX(0);
   }
-
+  
   .sidebar-toggle {
     display: none;
   }
-
+  
   .mobile-menu-btn {
     display: flex;
   }
-
-  .schedule-app-surface {
-    padding: 0;
-    border: none;
-    box-shadow: none;
+  
+  .schedule-main-content {
+    padding: 0 15px 15px;
   }
-
-  .schedule-main-card {
-    border-radius: 18px;
-  }
-
+  
   /* Overlay when sidebar is open on mobile */
   .sidebar:not(.collapsed)::after {
     content: '';
@@ -2268,37 +1964,19 @@ button.member-badge:hover {
 }
 
 @media (max-width: 768px) {
+  .schedule-main-content {
+    padding: 0 10px 10px;
+  }
+  
   .sidebar {
     width: 260px;
   }
-
+  
   .mobile-menu-btn {
     width: 45px;
     height: 45px;
     top: 15px;
     left: 15px;
-  }
-
-  .schedule-main-content {
-    padding: 16px;
-  }
-
-  .schedule-hero-meta {
-    grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-  }
-
-  .schedule-hero-panel {
-    padding: 20px;
-  }
-
-  .schedule-view-btn {
-    width: 100%;
-    justify-content: center;
-  }
-
-  .schedule-header-actions {
-    flex-direction: column;
-    align-items: stretch;
   }
 }
 


### PR DESCRIPTION
## Summary
- restore the FamilySchedule component to the state at commit 82ca560, including the original data loading flow and layout
- revert familjeschema neobrutalism styles to their previous design prior to the recent UI changes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2156cd49483238782a53b09cc6bae