### PR TITLE
Simplify family schedule sidebar layout

### DIFF
--- a/src/components/familjeschema/components/Sidebar.tsx
+++ b/src/components/familjeschema/components/Sidebar.tsx
@@ -151,9 +151,37 @@ export const Sidebar: React.FC<SidebarProps> = ({
           {isCollapsed ? <ChevronRight size={20} /> : <ChevronLeft size={20} />}
         </button>
 
-        {/* Week Navigation */}
-        <div className="sidebar-section">
-          {!isCollapsed && <h3 className="sidebar-heading">VECKA</h3>}
+        {/* Week Navigation & View Mode */}
+        <div className="sidebar-section sidebar-top-controls">
+          <div className="view-mode-inline">
+            {showLabels && (
+              <span className="sidebar-heading sidebar-heading-inline">VY</span>
+            )}
+            <div className="view-mode-buttons">
+              <button
+                className={`btn-square ${viewMode === 'grid' ? 'active' : ''}`}
+                onClick={() => onSetViewMode('grid')}
+                title="Rutnätsvy"
+                aria-label="Rutnätsvy"
+                aria-pressed={viewMode === 'grid'}
+                type="button"
+              >
+                <Grid3x3 size={18} />
+                <span className="sr-only">Rutnätsvy</span>
+              </button>
+              <button
+                className={`btn-square ${viewMode === 'layer' ? 'active' : ''}`}
+                onClick={() => onSetViewMode('layer')}
+                title="Lagervy"
+                aria-label="Lagervy"
+                aria-pressed={viewMode === 'layer'}
+                type="button"
+              >
+                <Layers size={18} />
+                <span className="sr-only">Lagervy</span>
+              </button>
+            </div>
+          </div>
           <div className="sidebar-week-nav">
             <button
               className="btn-compact btn-icon-small"
@@ -272,65 +300,50 @@ export const Sidebar: React.FC<SidebarProps> = ({
           </div>
         </div>
 
-        {/* View Mode */}
-        <div className="sidebar-section">
-          {!isCollapsed && <h3 className="sidebar-heading">VY</h3>}
-          <div className="view-mode-buttons">
-            <button
-              className={`btn-compact ${viewMode === 'grid' ? 'active' : ''}`}
-              onClick={() => onSetViewMode('grid')}
-              title="Rutnätsvy"
-            >
-              <Grid3x3 size={18} />
-              {!isCollapsed && <span>Rutnät</span>}
-            </button>
-            <button
-              className={`btn-compact ${viewMode === 'layer' ? 'active' : ''}`}
-              onClick={() => onSetViewMode('layer')}
-              title="Lagervy"
-            >
-              <Layers size={18} />
-              {!isCollapsed && <span>Lager</span>}
-            </button>
-          </div>
-        </div>
-
         {/* Actions */}
         <div className="sidebar-section sidebar-actions">
-          <button
-            className="btn-compact btn-primary"
-            onClick={onNewActivity}
-            title="Ny aktivitet"
-          >
-            <Plus size={18} />
-            {!isCollapsed && <span>Ny aktivitet</span>}
-          </button>
-          <button
-            className="btn-compact"
-            onClick={onOpenDataModal}
-            title="Import/Export"
-          >
-            <ArrowRightLeft size={18} />
-            {!isCollapsed && <span>Import/Export</span>}
-          </button>
-          <button
-            type="button"
-            className="btn-compact"
-            onClick={() => onSystemPrint?.()}
-            title="Skriv ut"
-            aria-label="Skriv ut"
-          >
-            <Printer size={18} />
-            {!isCollapsed && <span>Skriv ut</span>}
-          </button>
-          <button
-            className="btn-compact"
-            onClick={onOpenSettings}
-            title="Inställningar"
-          >
-            <Settings size={18} />
-            {!isCollapsed && <span>Inställningar</span>}
-          </button>
+          <div className="sidebar-action-buttons">
+            <button
+              className="btn-square btn-primary"
+              onClick={onNewActivity}
+              title="Ny aktivitet"
+              aria-label="Ny aktivitet"
+              type="button"
+            >
+              <Plus size={18} />
+              <span className="sr-only">Ny aktivitet</span>
+            </button>
+            <button
+              className="btn-square"
+              onClick={onOpenDataModal}
+              title="Import/Export"
+              aria-label="Import/Export"
+              type="button"
+            >
+              <ArrowRightLeft size={18} />
+              <span className="sr-only">Importera eller exportera</span>
+            </button>
+            <button
+              type="button"
+              className="btn-square"
+              onClick={() => onSystemPrint?.()}
+              title="Skriv ut"
+              aria-label="Skriv ut"
+            >
+              <Printer size={18} />
+              <span className="sr-only">Skriv ut</span>
+            </button>
+            <button
+              className="btn-square"
+              onClick={onOpenSettings}
+              title="Inställningar"
+              aria-label="Inställningar"
+              type="button"
+            >
+              <Settings size={18} />
+              <span className="sr-only">Inställningar</span>
+            </button>
+          </div>
           {!isCollapsed && (
             <div className="sidebar-quick-import" role="region" aria-label="Snabbimport av JSON">
               <label htmlFor="sidebar-quick-import" className="sr-only">

--- a/src/components/familjeschema/styles/neobrutalism.css
+++ b/src/components/familjeschema/styles/neobrutalism.css
@@ -1439,8 +1439,8 @@ button.member-badge:hover {
 /* Sidebar Styles */
 .sidebar {
   width: 280px;
-  background: var(--neo-white);
-  border-right: 3px solid var(--neo-black);
+  background: #f8fafc;
+  border-right: 1px solid #e2e8f0;
   display: flex;
   flex-direction: column;
   position: sticky;
@@ -1515,16 +1515,23 @@ button.member-badge:hover {
 
 /* Sidebar Sections */
 .sidebar-section {
-  padding: 15px;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+  padding: 16px;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.sidebar-top-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding-top: 20px;
 }
 
 .sidebar-heading {
   font-size: 0.75rem;
-  font-weight: 700;
-  letter-spacing: 1px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
   margin-bottom: 10px;
-  opacity: 0.7;
+  color: #64748b;
   text-transform: uppercase;
 }
 
@@ -1536,8 +1543,8 @@ button.member-badge:hover {
 .sidebar-week-nav {
   display: flex;
   align-items: center;
-  gap: 5px;
-  margin-bottom: 10px;
+  gap: 8px;
+  margin-bottom: 8px;
 }
 
 .sidebar.collapsed .sidebar-week-nav {
@@ -1547,16 +1554,18 @@ button.member-badge:hover {
 .week-display {
   flex: 1;
   padding: 8px;
-  background: var(--neo-white);
-  border: 2px solid var(--neo-black);
+  background: #ffffff;
+  border: 1px solid #cbd5f5;
+  border-radius: 8px;
   text-align: center;
-  font-weight: 700;
+  font-weight: 600;
   cursor: pointer;
-  transition: background 0.2s;
+  transition: background 0.15s ease, border-color 0.15s ease;
 }
 
 .week-display:hover {
-  background: var(--neo-cyan);
+  background: #eef2ff;
+  border-color: #a5b4fc;
 }
 
 .week-number {
@@ -1570,32 +1579,35 @@ button.member-badge:hover {
 /* Compact Buttons */
 .btn-compact {
   padding: 8px 12px;
-  border: 2px solid var(--neo-black);
-  background: var(--neo-white);
+  border: 1px solid #d0d5dd;
+  background: #ffffff;
   font-family: 'Space Grotesk', monospace;
   font-weight: 600;
   font-size: 0.85rem;
   cursor: pointer;
-  transition: all 0.1s;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
   display: flex;
   align-items: center;
   gap: 8px;
   width: 100%;
   justify-content: flex-start;
+  border-radius: 8px;
 }
 
 .btn-compact:hover {
-  background: var(--neo-yellow);
-  transform: translate(-1px, -1px);
-  box-shadow: var(--shadow-sm);
+  background: #f1f5f9;
+  border-color: #cbd5e1;
 }
 
 .btn-compact.active {
-  background: var(--neo-green);
+  background: #d1fae5;
+  border-color: #34d399;
+  color: #047857;
 }
 
 .btn-compact.btn-primary {
-  background: var(--neo-purple);
+  background: #0ea5e9;
+  border-color: #0284c7;
   color: var(--neo-white);
 }
 
@@ -1622,8 +1634,8 @@ button.member-badge:hover {
 
 .btn-subtle {
   padding: 6px 10px;
-  border: 1px dashed var(--neo-black);
-  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid #e2e8f0;
+  background: #f8fafc;
   font-family: 'Space Grotesk', monospace;
   font-weight: 600;
   font-size: 0.75rem;
@@ -1631,14 +1643,14 @@ button.member-badge:hover {
   align-items: center;
   gap: 6px;
   cursor: pointer;
-  transition: all 0.1s ease-in-out;
-  color: var(--neo-black);
+  transition: background 0.15s ease, border-color 0.15s ease;
+  color: #334155;
+  border-radius: 999px;
 }
 
 .btn-subtle:hover {
-  background: rgba(255, 223, 61, 0.4);
-  transform: translate(-1px, -1px);
-  box-shadow: var(--shadow-sm);
+  background: #e2e8f0;
+  border-color: #cbd5e1;
 }
 
 .btn-subtle:disabled {
@@ -1783,31 +1795,100 @@ button.member-badge:hover {
 /* View Mode Buttons */
 .view-mode-buttons {
   display: flex;
-  gap: 5px;
+  gap: 8px;
 }
 
 .sidebar.collapsed .view-mode-buttons {
   flex-direction: column;
+  align-items: center;
+}
+
+.view-mode-inline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.sidebar-heading-inline {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  color: #64748b;
+}
+
+.btn-square {
+  width: 40px;
+  height: 40px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid #d0d5dd;
+  background: #ffffff;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+  color: #0f172a;
+}
+
+.btn-square:hover {
+  background: #f1f5f9;
+  border-color: #cbd5e1;
+}
+
+.btn-square.active {
+  background: #d1fae5;
+  border-color: #34d399;
+  color: #047857;
+}
+
+.btn-square.btn-primary {
+  background: #0ea5e9;
+  border-color: #0284c7;
+  color: var(--neo-white);
+}
+
+.sidebar.collapsed .view-mode-inline {
+  flex-direction: column;
+  gap: 8px;
+  align-items: center;
+}
+
+.sidebar.collapsed .btn-square {
+  width: 36px;
+  height: 36px;
+}
+
+.sidebar-action-buttons {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.sidebar.collapsed .sidebar-action-buttons {
+  grid-template-columns: 1fr;
+  gap: 10px;
+  align-items: center;
+  justify-items: center;
 }
 
 /* Actions Section */
 .sidebar-actions {
-  padding-top: 15px;
+  padding-top: 16px;
   padding-bottom: 20px;
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  border-top: 2px solid var(--neo-black);
-  background: var(--neo-bg);
+  gap: 16px;
+  border-top: 1px solid #e2e8f0;
+  background: #f8fafc;
 }
 
 .sidebar-quick-import {
   margin-top: 4px;
-  padding: 10px;
-  border: 2px solid var(--neo-black);
+  padding: 12px;
+  border: 1px solid #e2e8f0;
   border-radius: 12px;
-  background: var(--neo-white);
-  box-shadow: var(--shadow-sm);
+  background: #ffffff;
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -1818,19 +1899,19 @@ button.member-badge:hover {
   min-height: 70px;
   resize: vertical;
   padding: 8px 10px;
-  border: 2px dashed var(--neo-black);
+  border: 1px solid #d0d5dd;
   border-radius: 10px;
   font-size: 0.85rem;
   line-height: 1.4;
   font-family: 'Space Grotesk', monospace;
-  background: var(--neo-bg);
-  transition: box-shadow 0.2s ease, border-color 0.2s ease;
+  background: #f8fafc;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
 .sidebar-quick-import-input:focus {
   outline: none;
-  border-style: solid;
-  box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.1);
+  border-color: #6366f1;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
 }
 
 .sidebar-quick-import-actions {


### PR DESCRIPTION
## Summary
- move the family schedule view toggle into the week header and show icon-only buttons with accessibility labels
- replace the sidebar action buttons with a square icon grid and refresh quick-import spacing
- tune the sidebar styles for a flatter 1px aesthetic across week picker, buttons, and actions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e62d7ead0083238634605115c4f562