### PR TITLE
Adjust familjeschema sidebar layout and sizing

### DIFF
--- a/src/components/familjeschema/components/Sidebar.tsx
+++ b/src/components/familjeschema/components/Sidebar.tsx
@@ -143,7 +143,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
       {/* Sidebar */}
       <aside className={`sidebar ${isCollapsed ? 'collapsed' : ''}`}>
         {/* Toggle Button */}
-        <button 
+        <button
           className="sidebar-toggle"
           onClick={() => setIsCollapsed(!isCollapsed)}
           aria-label={isCollapsed ? 'Expandera sidopanel' : 'Minimera sidopanel'}
@@ -151,34 +151,38 @@ export const Sidebar: React.FC<SidebarProps> = ({
           {isCollapsed ? <ChevronRight size={20} /> : <ChevronLeft size={20} />}
         </button>
 
-        {/* View Mode at Top */}
-        <div className="view-mode-buttons">
-          <button
-            className={`btn-square ${viewMode === 'grid' ? 'active' : ''}`}
-            onClick={() => onSetViewMode('grid')}
-            title="Rutnätsvy"
-            aria-label="Rutnätsvy"
-            aria-pressed={viewMode === 'grid'}
-            type="button"
-          >
-            <Grid3x3 size={20} />
-            <span className="sr-only">Rutnätsvy</span>
-          </button>
-          <button
-            className={`btn-square ${viewMode === 'layer' ? 'active' : ''}`}
-            onClick={() => onSetViewMode('layer')}
-            title="Lagervy"
-            aria-label="Lagervy"
-            aria-pressed={viewMode === 'layer'}
-            type="button"
-          >
-            <Layers size={20} />
-            <span className="sr-only">Lagervy</span>
-          </button>
-        </div>
-
-        {/* Week Navigation */}
+        {/* Week Navigation & View Mode */}
         <div className="sidebar-section sidebar-top-controls">
+          <div className="view-mode-inline">
+            {showLabels && (
+              <span className="sidebar-heading-inline" aria-hidden="true">VY</span>
+            )}
+            <div className="view-mode-buttons">
+              <button
+                className={`btn-square ${viewMode === 'grid' ? 'active' : ''}`}
+                onClick={() => onSetViewMode('grid')}
+                title="Rutnätsvy"
+                aria-label="Rutnätsvy"
+                aria-pressed={viewMode === 'grid'}
+                type="button"
+              >
+                <Grid3x3 size={20} />
+                <span className="sr-only">Rutnätsvy</span>
+              </button>
+              <button
+                className={`btn-square ${viewMode === 'layer' ? 'active' : ''}`}
+                onClick={() => onSetViewMode('layer')}
+                title="Lagervy"
+                aria-label="Lagervy"
+                aria-pressed={viewMode === 'layer'}
+                type="button"
+              >
+                <Layers size={20} />
+                <span className="sr-only">Lagervy</span>
+              </button>
+            </div>
+          </div>
+
           <div className="sidebar-week-nav">
             <button
               className="btn-compact btn-icon-small"
@@ -216,84 +220,87 @@ export const Sidebar: React.FC<SidebarProps> = ({
           )}
         </div>
 
-        {/* Family Members */}
-        <div className="sidebar-section">
-          <div className="sidebar-heading-row">
-            {showLabels && <h3 className="sidebar-heading">FAMILJ</h3>}
-            <button
-              type="button"
-              className={`btn-subtle ${isReorderingMembers ? 'active' : ''}`}
-              onClick={isReorderingMembers ? onSubmitReorder : onStartReorder}
-              disabled={isReorderingMembers ? isSavingMemberOrder : !canReorder}
-              title={isReorderingMembers ? 'Spara ny ordning' : 'Ändra ordning'}
-              aria-label={isReorderingMembers ? 'Spara ny ordning' : 'Aktivera omordning'}
+        {/* Scrollable content wrapper */}
+        <div className="sidebar-scrollable-content">
+          {/* Family Members */}
+          <div className="sidebar-section family-members-section">
+            <div className="sidebar-heading-row">
+              {showLabels && <h3 className="sidebar-heading">FAMILJ</h3>}
+              <button
+                type="button"
+                className={`btn-subtle ${isReorderingMembers ? 'active' : ''}`}
+                onClick={isReorderingMembers ? onSubmitReorder : onStartReorder}
+                disabled={isReorderingMembers ? isSavingMemberOrder : !canReorder}
+                title={isReorderingMembers ? 'Spara ny ordning' : 'Ändra ordning'}
+                aria-label={isReorderingMembers ? 'Spara ny ordning' : 'Aktivera omordning'}
+              >
+                {isReorderingMembers ? (
+                  <>
+                    {isSavingMemberOrder ? (
+                      <Loader2 size={16} className="icon-spin" />
+                    ) : (
+                      <Check size={16} />
+                    )}
+                    {showLabels && <span>{isSavingMemberOrder ? 'Sparar...' : 'Spara ordning'}</span>}
+                  </>
+                ) : (
+                  <>
+                    <GripVertical size={16} />
+                    {showLabels && <span>Ändra ordning</span>}
+                  </>
+                )}
+              </button>
+            </div>
+            <div
+              className={membersClassName}
+              onDragOver={handleContainerDragOver}
+              onDrop={handleDragEnd}
             >
-              {isReorderingMembers ? (
-                <>
-                  {isSavingMemberOrder ? (
-                    <Loader2 size={16} className="icon-spin" />
-                  ) : (
-                    <Check size={16} />
-                  )}
-                  {showLabels && <span>{isSavingMemberOrder ? 'Sparar...' : 'Spara ordning'}</span>}
-                </>
-              ) : (
-                <>
-                  <GripVertical size={16} />
-                  {showLabels && <span>Ändra ordning</span>}
-                </>
-              )}
-            </button>
-          </div>
-          <div
-            className={membersClassName}
-            onDragOver={handleContainerDragOver}
-            onDrop={handleDragEnd}
-          >
-            {familyMembers.map(member => {
-              const isDragging = draggedMemberId === member.id;
-              const isDragOver =
-                dragOverMemberId === member.id && draggedMemberId !== member.id;
-              const memberClassName = [
-                'sidebar-member',
-                isReorderingMembers ? 'reordering' : '',
-                isDragging ? 'dragging' : '',
-                isDragOver ? 'drag-over' : '',
-              ].filter(Boolean).join(' ');
+              {familyMembers.map(member => {
+                const isDragging = draggedMemberId === member.id;
+                const isDragOver =
+                  dragOverMemberId === member.id && draggedMemberId !== member.id;
+                const memberClassName = [
+                  'sidebar-member',
+                  isReorderingMembers ? 'reordering' : '',
+                  isDragging ? 'dragging' : '',
+                  isDragOver ? 'drag-over' : '',
+                ].filter(Boolean).join(' ');
 
-              return (
-                <button
-                  key={member.id}
-                  type="button"
-                  className={memberClassName}
-                  onClick={() => {
-                    if (isReorderingMembers) return;
-                    onMemberClick(member.id);
-                  }}
-                  title={member.name}
-                  style={{ borderLeftColor: member.color }}
-                  draggable={isReorderingMembers}
-                  onDragStart={event => handleDragStart(event, member.id)}
-                  onDragOver={event => handleDragOver(event, member.id)}
-                  onDragEnd={handleDragEnd}
-                  onDrop={handleDragEnd}
-                  aria-grabbed={isReorderingMembers && isDragging}
-                >
-                  {isReorderingMembers && (
-                    <span className="reorder-handle" aria-hidden="true">
-                      <GripVertical size={14} />
-                    </span>
-                  )}
-                  <span className="member-icon"><Emoji emoji={member.icon} /></span>
-                  {showLabels && (
-                    <>
-                      <span className="member-name">{member.name}</span>
-                      <span className="member-color-dot" style={{ background: member.color }}></span>
-                    </>
-                  )}
-                </button>
-              );
-            })}
+                return (
+                  <button
+                    key={member.id}
+                    type="button"
+                    className={memberClassName}
+                    onClick={() => {
+                      if (isReorderingMembers) return;
+                      onMemberClick(member.id);
+                    }}
+                    title={member.name}
+                    style={{ borderLeftColor: member.color }}
+                    draggable={isReorderingMembers}
+                    onDragStart={event => handleDragStart(event, member.id)}
+                    onDragOver={event => handleDragOver(event, member.id)}
+                    onDragEnd={handleDragEnd}
+                    onDrop={handleDragEnd}
+                    aria-grabbed={isReorderingMembers && isDragging}
+                  >
+                    {isReorderingMembers && (
+                      <span className="reorder-handle" aria-hidden="true">
+                        <GripVertical size={14} />
+                      </span>
+                    )}
+                    <span className="member-icon"><Emoji emoji={member.icon} /></span>
+                    {showLabels && (
+                      <>
+                        <span className="member-name">{member.name}</span>
+                        <span className="member-color-dot" style={{ background: member.color }}></span>
+                      </>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
           </div>
         </div>
 

--- a/src/components/familjeschema/styles/neobrutalism.css
+++ b/src/components/familjeschema/styles/neobrutalism.css
@@ -1439,17 +1439,24 @@ button.member-badge:hover {
 /* Sidebar Styles */
 .sidebar {
   width: 280px;
-  background: #ffffff;
-  border-right: 2px solid var(--neo-black);
+  background: #f8fafc;
+  border-right: 1px solid #e2e8f0;
   display: flex;
   flex-direction: column;
   position: sticky;
   top: 0;
   height: 100vh;
-  overflow-y: auto;
-  overflow-x: hidden;
+  overflow: hidden;
   transition: width 0.3s ease;
   z-index: 30;
+}
+
+.sidebar-scrollable-content {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  display: flex;
+  flex-direction: column;
 }
 
 .sidebar.collapsed {
@@ -1522,10 +1529,16 @@ button.member-badge:hover {
   padding: 16px;
 }
 
+.sidebar-section.family-members-section {
+  max-height: 40vh;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
 .sidebar-top-controls {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 12px;
   padding-top: 4px;
 }
 
@@ -1691,29 +1704,36 @@ button.member-badge:hover {
 /* View Mode Buttons - Moved to top */
 .view-mode-buttons {
   display: flex;
-  gap: 5px;
+  gap: 8px;
+  justify-content: center;
 }
 
 .sidebar.collapsed .view-mode-buttons {
   flex-direction: column;
-  gap: 5px;
+  gap: 8px;
 }
 
 .view-mode-inline {
   display: flex;
+  flex-direction: column;
   align-items: center;
-  justify-content: space-between;
-  gap: 6px;
+  gap: 8px;
 }
 
 .sidebar-heading-inline {
-  display: none;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: rgba(0, 0, 0, 0.6);
+  text-transform: uppercase;
+  text-align: center;
+  width: 100%;
 }
 
 
 .btn-square {
-  width: 22px;
-  height: 22px;
+  width: 32px;
+  height: 32px;
   border: 2px solid var(--neo-black);
   background: var(--neo-white);
   display: inline-flex;
@@ -1728,8 +1748,8 @@ button.member-badge:hover {
 }
 
 .btn-square svg {
-  width: 14px;
-  height: 14px;
+  width: 16px;
+  height: 16px;
 }
 
 .btn-square:hover {
@@ -1771,8 +1791,8 @@ button.member-badge:hover {
 }
 
 .sidebar.collapsed .btn-square {
-  width: 20px;
-  height: 20px;
+  width: 30px;
+  height: 30px;
 }
 
 .sidebar.collapsed .btn-square-large {
@@ -1811,12 +1831,12 @@ button.member-badge:hover {
 .sidebar.collapsed .view-mode-inline {
   flex-direction: column;
   align-items: center;
-  gap: 8px;
+  gap: 10px;
 }
 
 .sidebar.collapsed .view-mode-buttons {
   flex-direction: column;
-  gap: 5px;
+  gap: 8px;
 }
 
 .sidebar.collapsed .sidebar-action-buttons {
@@ -1835,7 +1855,8 @@ button.member-badge:hover {
   align-items: center;
   justify-content: space-between;
   gap: 8px;
-  margin-bottom: 8px;
+  margin-bottom: 10px;
+  flex-shrink: 0;
 }
 
 .sidebar-heading-row .btn-subtle {
@@ -1968,12 +1989,13 @@ button.member-badge:hover {
 
 /* Actions Section */
 .sidebar-actions {
-  padding: 24px 16px;
+  padding-top: 12px;
+  padding-bottom: 12px;
   display: flex;
   flex-direction: column;
-  gap: 20px;
-  border-top: 2px solid #f0f0f0;
-  background: #ffffff;
+  gap: 12px;
+  border-top: 1px solid #e2e8f0;
+  background: #f8fafc;
   margin-top: auto;
 }
 


### PR DESCRIPTION
## Summary
- enlarge the view mode toggle buttons and center them with a visible label
- restructure the familjeschema sidebar to add a scrollable family section and sticky actions
- update sidebar styling for improved spacing in both expanded and collapsed states

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e651032bcc8323a0809387ed63cf3b