### PR TITLE
Adjust sidebar member layout for compact view

### DIFF
--- a/src/components/familjeschema/components/Sidebar.tsx
+++ b/src/components/familjeschema/components/Sidebar.tsx
@@ -291,12 +291,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
                       </span>
                     )}
                     <span className="member-icon"><Emoji emoji={member.icon} /></span>
-                    {showLabels && (
-                      <>
-                        <span className="member-name">{member.name}</span>
-                        <span className="member-color-dot" style={{ background: member.color }}></span>
-                      </>
-                    )}
+                    {showLabels && <span className="member-name">{member.name}</span>}
                   </button>
                 );
               })}

--- a/src/components/familjeschema/styles/neobrutalism.css
+++ b/src/components/familjeschema/styles/neobrutalism.css
@@ -1890,7 +1890,7 @@ button.member-badge:hover {
 .sidebar-members {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  gap: 8px;
+  gap: 6px;
   position: relative;
 }
 
@@ -1912,8 +1912,8 @@ button.member-badge:hover {
 .sidebar-member {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 12px;
+  gap: 8px;
+  padding: 8px;
   background: var(--neo-white);
   border: 2px solid var(--neo-black);
   border-left: 4px solid;
@@ -1922,7 +1922,7 @@ button.member-badge:hover {
   font-family: 'Space Grotesk', 'Apple Color Emoji', 'Segoe UI Emoji',
     'Noto Color Emoji', sans-serif;
   font-weight: 600;
-  font-size: 0.9rem;
+  font-size: 0.85rem;
   width: 100%;
   border-radius: 0;
 }
@@ -1960,26 +1960,23 @@ button.member-badge:hover {
 }
 
 .member-icon {
-  font-size: 1.4rem;
-  width: 30px;
+  font-size: 1.2rem;
+  width: 24px;
   display: flex;
   justify-content: center;
+  flex-shrink: 0;
 }
 
 .member-name {
   flex: 1;
   text-align: left;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
 }
 
-.member-color-dot {
-  width: 16px;
-  height: 16px;
-  border: 2px solid var(--neo-black);
-  border-radius: 50%;
-}
-
-.sidebar.collapsed .member-name,
-.sidebar.collapsed .member-color-dot {
+.sidebar.collapsed .member-name {
   display: none;
 }
 


### PR DESCRIPTION
## Summary
- tighten sidebar member spacing and typography for the compact two-column layout
- ensure member names truncate gracefully and rely on the left border color for identification
- simplify the sidebar markup by removing the unused member color dot element

## Testing
- npm run dev *(fails: Next.js telemetry/version fetch requires network access in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e66285a8dc8323a9a0cc4a522b2799