### PR TITLE
Extract schedule statistics logic into reusable utility module

### DIFF
--- a/src/components/schedule/NewSchedulePlanner.tsx
+++ b/src/components/schedule/NewSchedulePlanner.tsx
@@ -40,6 +40,7 @@ import {
   checkOverlap, EVENT_GAP_PX, MIN_HEIGHT_PX
 } from '@/utils/scheduleTime';
 import { buildDayLayout, DayLayoutEntry } from '@/utils/scheduleLayout';
+import { mergeIntervalMinutes, totalMinutesByTeacher, totalMinutesByTitle } from '@/utils/scheduleStats';
 import { runLayoutFixtureValidation } from '@/components/schedule/layoutValidation';
 import { DraggableSourceCard } from '@/components/schedule/DraggableSourceCard';
 import { ScheduledEventCard } from '@/components/schedule/ScheduledEventCard';
@@ -388,49 +389,14 @@ const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
   }, [schedule]);
 
   // Statistics
-  const scheduleStats = useMemo(() => {
-    const visibleSchedule = schedule.filter(entry => advancedFilterMatch(entry, filterQuery));
-    const intervalsByDayAndTitle: Record<string, Record<string, { start: number; end: number }[]>> = {};
+  const visibleSchedule = useMemo(
+    () => schedule.filter(entry => advancedFilterMatch(entry, filterQuery)),
+    [schedule, filterQuery]
+  );
 
-    visibleSchedule.forEach(entry => {
-      if (!intervalsByDayAndTitle[entry.day]) intervalsByDayAndTitle[entry.day] = {};
-      if (!intervalsByDayAndTitle[entry.day][entry.title]) intervalsByDayAndTitle[entry.day][entry.title] = [];
-      
-      intervalsByDayAndTitle[entry.day][entry.title].push({
-        start: timeToMinutes(entry.startTime),
-        end: timeToMinutes(entry.endTime),
-      });
-    });
+  const scheduleStats = useMemo(() => totalMinutesByTitle(visibleSchedule), [visibleSchedule]);
 
-    const stats: Record<string, number> = {};
-
-    Object.entries(intervalsByDayAndTitle).forEach(([day, subjects]) => {
-      Object.entries(subjects).forEach(([title, intervals]) => {
-        if (intervals.length === 0) return;
-        
-        const sorted = [...intervals].sort((a, b) => a.start - b.start);
-        let totalForDay = 0;
-        let currentStart = sorted[0].start;
-        let currentEnd = sorted[0].end;
-
-        sorted.slice(1).forEach(interval => {
-          if (interval.start <= currentEnd) {
-            currentEnd = Math.max(currentEnd, interval.end);
-          } else {
-            totalForDay += currentEnd - currentStart;
-            currentStart = interval.start;
-            currentEnd = interval.end;
-          }
-        });
-        totalForDay += currentEnd - currentStart;
-
-        if (!stats[title]) stats[title] = 0;
-        stats[title] += totalForDay;
-      });
-    });
-
-    return Object.entries(stats).sort((a, b) => b[1] - a[1]);
-  }, [schedule, filterQuery]);
+  const teacherStats = useMemo(() => totalMinutesByTeacher(visibleSchedule), [visibleSchedule]);
 
   const hoursFormatter = useMemo(() => new Intl.NumberFormat('sv-SE', {
     minimumFractionDigits: 1,
@@ -475,21 +441,8 @@ const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
     Object.entries(intervalsByDay).forEach(([day, subjects]) => {
       Object.entries(subjects).forEach(([title, intervals]) => {
         if (intervals.length === 0) return;
-        const sorted = [...intervals].sort((a, b) => a.start - b.start);
-        let total = 0;
-        let currentStart = sorted[0].start;
-        let currentEnd = sorted[0].end;
-        sorted.slice(1).forEach(interval => {
-          if (interval.start < currentEnd && interval.end > currentStart) {
-            currentEnd = Math.max(currentEnd, interval.end);
-          } else {
-            total += currentEnd - currentStart;
-            currentStart = interval.start;
-            currentEnd = interval.end;
-          }
-        });
-        total += currentEnd - currentStart;
-        totals[day][title] = total;
+        if (!totals[day]) totals[day] = {};
+        totals[day][title] = mergeIntervalMinutes(intervals);
       });
     });
     return totals;
@@ -1033,14 +986,30 @@ const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
                       <BarChart3 size={14} /> 
                       <span className="text-xs font-bold uppercase">Tid (Filtrerat)</span>
                     </div>
+                    <div className="text-[10px] font-bold uppercase text-gray-400 mb-1">Ämnen</div>
                     <div className="space-y-1 text-xs max-h-[100px] overflow-y-auto">
-                      {scheduleStats.length === 0 ? <span className="text-gray-400 italic">Inget schemalagt</span> : 
+                      {scheduleStats.length === 0 ? <span className="text-gray-400 italic">Inget schemalagt</span> :
                         scheduleStats.slice(0, 10).map(([title, minutes]) => {
                           const hours = minutes / 60;
                           return (
                             <div key={title} className="flex justify-between">
                               <span>{title}</span>
                               <span className="font-mono font-bold">{hoursFormatter.format(hours)} h</span>
+                            </div>
+                          );
+                        })
+                      }
+                    </div>
+
+                    <div className="text-[10px] font-bold uppercase text-gray-400 mt-3 mb-1">Lärare</div>
+                    <div className="space-y-1 text-xs max-h-[100px] overflow-y-auto">
+                      {teacherStats.length === 0 ? <span className="text-gray-400 italic">Ingen lärare angiven</span> :
+                        teacherStats.map(([teacher, minutes]) => {
+                          const hours = minutes / 60;
+                          return (
+                            <div key={teacher} className="flex justify-between gap-2">
+                              <span className="truncate" title={teacher}>{teacher}</span>
+                              <span className="font-mono font-bold shrink-0">{hoursFormatter.format(hours)} h</span>
                             </div>
                           );
                         })

--- a/src/utils/scheduleStats.ts
+++ b/src/utils/scheduleStats.ts
@@ -1,0 +1,108 @@
+import { ScheduledEntry } from '@/types/schedule';
+import { timeToMinutes } from '@/utils/scheduleTime';
+
+export type TimeInterval = { start: number; end: number };
+
+/**
+ * Summerar hur många minuter en samling intervall täcker totalt.
+ * Överlappande (eller angränsande) intervall räknas bara en gång, så
+ * två parallella lektioner 08:00–09:00 ger 60 minuter, inte 120.
+ */
+export const mergeIntervalMinutes = (intervals: TimeInterval[]): number => {
+  if (intervals.length === 0) return 0;
+
+  const sorted = [...intervals].sort((a, b) => a.start - b.start);
+  let total = 0;
+  let currentStart = sorted[0].start;
+  let currentEnd = sorted[0].end;
+
+  sorted.slice(1).forEach(interval => {
+    if (interval.start <= currentEnd) {
+      currentEnd = Math.max(currentEnd, interval.end);
+    } else {
+      total += currentEnd - currentStart;
+      currentStart = interval.start;
+      currentEnd = interval.end;
+    }
+  });
+
+  return total + (currentEnd - currentStart);
+};
+
+/**
+ * Lärarfältet är fritext och kan innehålla flera lärare separerade med komma
+ * ("Anna, Björn") eftersom SmartTextInput autofyller på det sättet.
+ */
+export const splitTeacherNames = (value: unknown): string[] => {
+  if (typeof value !== 'string') return [];
+  return value
+    .split(',')
+    .map(name => name.trim())
+    .filter(Boolean);
+};
+
+type Grouped = {
+  /** Första stavningen vi såg – används som etikett i listan. */
+  label: string;
+  intervalsByDay: Record<string, TimeInterval[]>;
+};
+
+/**
+ * Grupperar poster per nyckel (t.ex. ämne eller lärare) och räknar ut hur
+ * många minuter varje nyckel täcker. Överlapp inom samma nyckel och dag
+ * räknas en gång; olika dagar summeras.
+ *
+ * `keysOf` får returnera flera nycklar per post – en lektion med två lärare
+ * ger båda lärarna full tid. `normalizeKey` avgör vilka nycklar som slås
+ * ihop till samma rad.
+ */
+const totalMinutesByKey = (
+  entries: ScheduledEntry[],
+  keysOf: (entry: ScheduledEntry) => string[],
+  normalizeKey: (key: string) => string = key => key
+): [string, number][] => {
+  const groups = new Map<string, Grouped>();
+
+  entries.forEach(entry => {
+    const interval = {
+      start: timeToMinutes(entry.startTime),
+      end: timeToMinutes(entry.endTime),
+    };
+
+    keysOf(entry).forEach(key => {
+      const normalized = normalizeKey(key);
+      let group = groups.get(normalized);
+      if (!group) {
+        group = { label: key, intervalsByDay: {} };
+        groups.set(normalized, group);
+      }
+      if (!group.intervalsByDay[entry.day]) {
+        group.intervalsByDay[entry.day] = [];
+      }
+      group.intervalsByDay[entry.day].push(interval);
+    });
+  });
+
+  return Array.from(groups.values())
+    .map(group => {
+      const minutes = Object.values(group.intervalsByDay)
+        .reduce((sum, intervals) => sum + mergeIntervalMinutes(intervals), 0);
+      return [group.label, minutes] as [string, number];
+    })
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0], 'sv'));
+};
+
+/** Timmar per ämnestitel, med parallella lektioner räknade en gång. */
+export const totalMinutesByTitle = (entries: ScheduledEntry[]): [string, number][] =>
+  totalMinutesByKey(entries, entry => (entry.title ? [entry.title] : []));
+
+/**
+ * Timmar per lärare, med parallella lektioner räknade en gång. Poster utan
+ * lärare hoppas över, och samma namn med olika versaler slås ihop.
+ */
+export const totalMinutesByTeacher = (entries: ScheduledEntry[]): [string, number][] =>
+  totalMinutesByKey(
+    entries,
+    entry => splitTeacherNames(entry.teacher),
+    key => key.toLocaleLowerCase('sv')
+  );


### PR DESCRIPTION
## Summary
Refactored schedule statistics calculations into a dedicated utility module (`scheduleStats.ts`) to improve code organization, reusability, and maintainability. Added teacher statistics display to the schedule planner UI.

## Key Changes
- **New utility module** (`src/utils/scheduleStats.ts`):
  - Extracted `mergeIntervalMinutes()` to calculate total duration of overlapping time intervals
  - Added `splitTeacherNames()` to parse comma-separated teacher names
  - Created `totalMinutesByKey()` as a generic grouping function for statistics
  - Implemented `totalMinutesByTitle()` and `totalMinutesByTeacher()` for subject and teacher statistics
  - Properly handles overlapping entries (counted once per day) and case-insensitive teacher name matching

- **Refactored NewSchedulePlanner.tsx**:
  - Replaced inline statistics calculation logic with calls to new utility functions
  - Extracted `visibleSchedule` into a separate memoized value for reuse
  - Simplified `scheduleStats` computation using `totalMinutesByTitle()`
  - Added `teacherStats` calculation using `totalMinutesByTeacher()`
  - Updated statistics panel UI to display both subject and teacher breakdowns with proper labels and styling

## Implementation Details
- Statistics correctly handle overlapping/parallel lessons (e.g., two lessons 08:00–09:00 = 60 minutes, not 120)
- Teacher names are normalized to lowercase for consistent grouping across different capitalizations
- Results are sorted by duration (descending) then alphabetically by name (Swedish locale)
- UI displays top 10 subjects and all teachers with formatted hour values

https://claude.ai/code/session_01E76G5X27F6Eh64yTMHg24j