### PR TITLE
Schemaplaneraren: hela lärarnamn på korten och indikator för aktivt schema

### DIFF
--- a/src/components/schedule/DebugPanels.tsx
+++ b/src/components/schedule/DebugPanels.tsx
@@ -80,7 +80,7 @@ function TeacherAvailabilityRow({ teacher, days, onChange }: TeacherAvailability
     <div className="border-2 border-black rounded p-2 bg-white">
       <div className="flex items-center justify-between gap-2">
         <div className="min-w-0">
-          <p className="font-bold text-sm truncate">{teacher}</p>
+          <p className="font-bold text-sm break-words">{teacher}</p>
           <p className="text-[11px] text-gray-500 truncate">{summary}</p>
         </div>
         <Button

--- a/src/components/schedule/NewSchedulePlanner.tsx
+++ b/src/components/schedule/NewSchedulePlanner.tsx
@@ -851,7 +851,7 @@ const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
           {teacherStats.length === 0 ? <span className="text-gray-400 italic">Ingen lärare angiven</span> :
             teacherStats.map(([teacher, minutes]) => (
               <div key={teacher} className="flex justify-between gap-2">
-                <span className="truncate" title={teacher}>{teacher}</span>
+                <span className="min-w-0 break-words" title={teacher}>{teacher}</span>
                 <span className="font-mono font-bold shrink-0">{formatMinutes(minutes)}</span>
               </div>
             ))

--- a/src/components/schedule/NewSchedulePlanner.tsx
+++ b/src/components/schedule/NewSchedulePlanner.tsx
@@ -894,8 +894,8 @@ const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
               <FeatureNavigation />
            </div>
            
-           <div className="flex-1 max-w-md w-full relative mr-auto">
-              <Input 
+           <div className="flex-1 max-w-md w-full relative">
+              <Input
                 value={filterQuery}
                 onChange={(e) => setFilterQuery(e.target.value)}
                 placeholder="Filter: 'Lärare'+'ämne'; -Ämne"
@@ -907,6 +907,19 @@ const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
               >
                 <Search className="h-5 w-5" />
               </div>
+           </div>
+
+           {/* Vilket schema som är aktivt syns annars bara i arkivlistan, som
+               ofta är hopfälld. Autospar skriver hit, därför står namnet framme. */}
+           <div
+             role="status"
+             className="mr-auto hidden min-w-0 shrink items-center gap-1.5 text-xs font-bold text-gray-500 cursor-help lg:flex"
+             title={activeArchiveName
+               ? `Aktivt schema: ${activeArchiveName}. Ändringar sparas hit.`
+               : 'Inget arkiv är aktivt. Ändringar sparas i huvudschemat.'}
+           >
+             <Archive size={12} className="shrink-0 opacity-60" />
+             <span className="truncate">{activeArchiveName ?? 'Huvudschema'}</span>
            </div>
 
            <div className="flex gap-2 flex-wrap">

--- a/src/components/schedule/ScheduledEventCard.tsx
+++ b/src/components/schedule/ScheduledEventCard.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { useDraggable } from '@dnd-kit/core';
 import { Edit2, FileText, Trash2 } from 'lucide-react';
 import { ScheduledEntry } from '@/types/schedule';
+import { splitTeacherNames } from '@/utils/scheduleStats';
 import { EVENT_GAP_PX, getPositionStyles, MIN_HEIGHT_PX } from '@/utils/scheduleTime';
 
 type ScheduledEventCardProps = {
@@ -56,6 +57,7 @@ export function ScheduledEventCard({
   const widthPercentage = 100 / Math.max(columnCount, 1);
   const leftPercentage = widthPercentage * columnIndex;
   const assignmentUrl = extractUrl(entry.category);
+  const teacherNames = splitTeacherNames(entry.teacher);
 
   if (hidden) return null;
 
@@ -119,10 +121,14 @@ export function ScheduledEventCard({
         {!isShortDuration && (
           <p className={`font-bold leading-tight truncate ${isCompactHeight ? 'text-xs' : 'text-sm'}`}>{entry.title}</p>
         )}
-        {adjustedHeight > 30 && entry.teacher && (
-          <p className={`text-gray-700 truncate leading-tight font-semibold ${isCompactHeight ? 'text-2xs' : 'text-xs'}`}>
-            {entry.teacher}
-          </p>
+        {adjustedHeight > 30 && teacherNames.length > 0 && (
+          /* Lärarnamn kortas aldrig av med "…" – varje namn får en egen rad och
+             bryts vid behov över flera rader. */
+          <div className={`shrink-0 text-gray-700 leading-tight font-semibold ${isCompactHeight ? 'text-2xs' : 'text-xs'}`}>
+            {teacherNames.map((name, index) => (
+              <p key={`${name}-${index}`} className="break-words">{name}</p>
+            ))}
+          </div>
         )}
         {adjustedHeight > 30 && entry.room && (
           <p className={`text-gray-700 truncate leading-tight ${isCompactHeight ? 'text-2xs' : 'text-xs'}`}>


### PR DESCRIPTION
Två fristående förbättringar i schemaplaneraren.

## 1. Lärarnamn kortas inte längre av med `…`

Varje lärare får en egen rad, och ett långt namn bryts över flera rader i stället för att döljas.

- **`ScheduledEventCard.tsx`** – huvudändringen. Lärarraden hade `truncate` (nowrap + ellips). Fritextfältet delas nu med den befintliga `splitTeacherNames()` (kommaseparerat), så varje lärare renderas som en egen rad med `break-words`. Blocket har `shrink-0`, vilket ger lärarnamnen företräde i kortets flex-kolumn — rum och anteckningar får stryka på foten först när kortet är lågt.
- **`NewSchedulePlanner.tsx`** – statistiklistan "Lärare" i sidopanelen radbryter (`min-w-0 break-words`) i stället för att kapa namnet; minuttalet till höger ligger kvar på sin rad.
- **`DebugPanels.tsx`** – samma sak för namnet i raderna för lärartillgänglighet. Sammanfattningsraden under (dagar/tider) är oförändrad.

Bakgrund: avkortade lärarnamn gick inte att läsa på smala kort — "Anna Andersson, Björn Bengtsson" blev "Anna Anders…".

**Att tänka på:** korten har `overflow-hidden` och en höjd som styrs av passets längd, så på ett kort pass med flera lärare kan sista raden klippas av kortets underkant. Det är den medvetna avvägningen här: hellre klippt av kortkanten än ersatt med ellips. PDF-exporten påverkas inte — `.pdf-export`-reglerna i `globals.css` släpper redan radbrytningen fri och tar bort höjdklippet.

## 2. Indikator för aktivt schema

Vilket arkiv som är aktivt syntes bara som `• aktiv` i arkivlistan, och den panelen är oftast hopfälld. Eftersom autospar skriver till just det arkivet (`usePlannerSync.ts`) svarar indikatorn egentligen på frågan "vart hamnar det jag ändrar nu?".

- Liten grå text med arkivikon, till höger om sökfältet i verktygsfältet. Visar arkivnamnet, eller `Huvudschema` när inget arkiv är aktivt (då redigeras basschemat).
- Ren läsindikator med tooltip — inga nya kontroller, ingen ny state. `role="status"` gör att skärmläsare läser upp namnet vid schemabyte.
- `mr-auto` flyttades från filterfältets wrapper till indikatorn, så knappgruppen ligger kvar i högerkanten precis som förut. `truncate` skyddar verktygsfältets bredd; hela namnet finns i tooltipen.
- Dold på mobil (`hidden lg:flex`) eftersom mobilheadern redan visar samma namn.

## Verifiering

`npx tsc --noEmit` rent, `pnpm lint` utan nya varningar (de tre kvarvarande fanns före ändringarna). Ingen av ändringarna är visuellt körd lokalt — schemasidan ligger bakom `ProtectedRoute` och hade krävt backend mot MySQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
